### PR TITLE
fix: concurrency issues in progress store, app.config, and temp files

### DIFF
--- a/application/services/document_service.py
+++ b/application/services/document_service.py
@@ -152,6 +152,9 @@ class DocumentProcessingService:
                 is_error=True,
                 error_message=enhanced_error,
             )
+        finally:
+            # Always clean up the uploaded file when processing finishes
+            self._cleanup_upload(saved_file_path)
 
     def _save_timing_data(self, base_filename: str, timing_metadata: "TimingMetadata") -> None:
         """Save timing metadata as JSON file."""
@@ -187,3 +190,14 @@ class DocumentProcessingService:
                     file_manager.schedule_cleanup(timing_filename, 2.0)
         except Exception as e:
             logger.error(f"Failed to save timing data: {e}")
+
+    @staticmethod
+    def _cleanup_upload(saved_file_path: str) -> None:
+        """Remove the uploaded file after processing completes or is cancelled."""
+        try:
+            path = Path(saved_file_path)
+            if path.exists():
+                path.unlink()
+                logger.debug("Cleaned up upload file: %s", saved_file_path)
+        except Exception:
+            logger.warning("Failed to clean up upload file: %s", saved_file_path, exc_info=True)

--- a/application/services/document_service.py
+++ b/application/services/document_service.py
@@ -194,6 +194,8 @@ class DocumentProcessingService:
     @staticmethod
     def _cleanup_upload(saved_file_path: str) -> None:
         """Remove the uploaded file after processing completes or is cancelled."""
+        if not saved_file_path:
+            return
         try:
             path = Path(saved_file_path)
             if path.exists():

--- a/application/services/progress_store.py
+++ b/application/services/progress_store.py
@@ -61,9 +61,18 @@ class ThreadSafeProgressStore:
         error_message: Optional[str] = None,
         result_data: Optional[dict[str, Any]] = None,
     ) -> None:
-        """Update progress for an operation (thread-safe)."""
+        """Update progress for an operation (thread-safe).
+
+        If the operation has been cancelled, the update is ignored to prevent
+        a racing background thread from overwriting the cancellation status.
+        """
         logger.debug("Progress [%s]: stage=%s, pct=%d%%, msg=%s", operation_id[:8], stage, percentage, message)
         with self._lock:
+            # Don't overwrite cancellation status with a regular update
+            if self._cancellation_flags.get(operation_id, False) and not is_complete and not is_error:
+                logger.debug("Progress [%s]: update ignored, operation is cancelled", operation_id[:8])
+                return
+
             self._progress[operation_id] = ProgressStatus(
                 operation_id=operation_id,
                 stage=stage,

--- a/routes.py
+++ b/routes.py
@@ -59,9 +59,6 @@ def background_process_document(
     """
     # Use the Flask app context for this thread
     with app.app_context():
-        # Store context in Flask app for access in helper functions if needed
-        app.config["APP_CONTEXT"] = app_context
-
         bg_logger = app_context.get_logger("routes.background")
         bg_logger.debug("Background thread started for operation %s, file: %s", operation_id[:8], original_filename)
         try:

--- a/tests/unit/test_progress_store.py
+++ b/tests/unit/test_progress_store.py
@@ -92,6 +92,30 @@ class TestThreadSafeProgressStore:
         store.cancel("op-3")
         assert store.is_cancelled("op-3") is True
 
+    def test_store_update_ignored_after_cancellation(self) -> None:
+        """Regular updates should be ignored after cancellation to prevent TOCTOU race."""
+        store = ThreadSafeProgressStore()
+        store.update("op-cancel", "processing", 50, "Working")
+        store.cancel("op-cancel")
+        # Regular update should be ignored — cancellation status preserved
+        store.update("op-cancel", "processing", 75, "Still working")
+        progress = store.get("op-cancel")
+        assert progress is not None
+        assert progress.stage == "cancelled"
+        assert progress.percentage == 50
+
+    def test_store_error_update_allowed_after_cancellation(self) -> None:
+        """Error/complete updates should pass through even after cancellation."""
+        store = ThreadSafeProgressStore()
+        store.update("op-err", "processing", 50, "Working")
+        store.cancel("op-err")
+        # Error update should pass through
+        store.update("op-err", "error", 0, "Failed", is_error=True, error_message="boom")
+        progress = store.get("op-err")
+        assert progress is not None
+        assert progress.is_error is True
+        assert progress.cancelled is True  # cancelled flag preserved
+
     def test_store_remove_operation(self) -> None:
         """Should remove operation from tracking."""
         store = ThreadSafeProgressStore()


### PR DESCRIPTION
## Summary
Fixes 3 concurrency-related issues:

1. **Progress store TOCTOU** — `update()` now skips writes for cancelled operations, preventing a racing background thread from overwriting the cancellation status set by `cancel()`.
2. **Redundant app.config write** — Removed `app.config["APP_CONTEXT"] = app_context` from background thread. The context was already set by app_factory; re-writing it from background threads was redundant and racy.
3. **Orphaned temp files** — Added `finally` block in `process_document_background()` that always cleans up the uploaded PDF file, whether processing succeeds, fails, or is cancelled.

Closes #29

## Test plan
- [x] All 147 unit tests pass
- [x] All 19 progress store tests pass
- [x] Zero ruff lint errors
- [ ] Manual: upload a PDF, cancel mid-processing, verify upload file is cleaned up