### PR TITLE
refactor: move pdfplumber behind IPdfTextExtractor in infrastructure

### DIFF
--- a/application/container/service_container.py
+++ b/application/container/service_container.py
@@ -80,12 +80,14 @@ class ServiceContainer(IServiceContainer):
             IDocumentEngine,
             IFileManager,
             ILLMProvider,
+            IPdfTextExtractor,
             ITextPipeline,
         )
         from domain.text.text_pipeline import TextPipeline
         from infrastructure.file.file_manager import FileManager
         from infrastructure.llm.gemini_llm_provider import GeminiLLMProvider
         from infrastructure.ocr.tesseract_ocr_provider import TesseractOCRProvider
+        from infrastructure.pdf.pdfplumber_text_extractor import PdfPlumberTextExtractor
 
         # Build all factories in a single immutable dict
         factories: dict[ServiceKey, ServiceFactory] = {
@@ -144,7 +146,10 @@ class ServiceContainer(IServiceContainer):
             IDocumentEngine: lambda: DocumentEngine(
                 ocr_provider=self.get(TesseractOCRProvider),
                 file_manager=self.get(FileManager),
+                pdf_extractor=self.get(IPdfTextExtractor),
             ),
+            # PDF Text Extractor
+            IPdfTextExtractor: lambda: PdfPlumberTextExtractor(),
             # OCR Provider
             TesseractOCRProvider: lambda: TesseractOCRProvider(config=self.config),
         }

--- a/domain/document/document_engine.py
+++ b/domain/document/document_engine.py
@@ -5,11 +5,8 @@ No exceptions thrown - all errors returned as Result[T].
 """
 
 from contextlib import suppress
-import io
 import logging
 from typing import Any
-
-import pdfplumber
 
 from ..errors import (
     ErrorCode,
@@ -17,7 +14,14 @@ from ..errors import (
     audio_generation_error,
     text_extraction_error,
 )
-from ..interfaces import IAudioEngine, IDocumentEngine, IFileManager, IOCRProvider, ITextPipeline
+from ..interfaces import (
+    IAudioEngine,
+    IDocumentEngine,
+    IFileManager,
+    IOCRProvider,
+    IPdfTextExtractor,
+    ITextPipeline,
+)
 from ..models import PageRange, PDFInfo, ProcessingRequest, TimedAudioResult
 
 logger = logging.getLogger(__name__)
@@ -33,11 +37,13 @@ class DocumentEngine(IDocumentEngine):
         self,
         ocr_provider: IOCRProvider,
         file_manager: IFileManager,
+        pdf_extractor: IPdfTextExtractor,
         min_text_threshold: int = 100,
         audio_target_chunk_size: int = 4000,
     ):
         self.ocr_provider = ocr_provider
         self.file_manager = file_manager
+        self.pdf_extractor = pdf_extractor
         self.min_text_threshold = min_text_threshold
         self.audio_target_chunk_size = audio_target_chunk_size
         logger.debug("DocumentEngine initialized with Result[T] pattern")
@@ -63,31 +69,30 @@ class DocumentEngine(IDocumentEngine):
 
         Returns Result with extracted text or error.
         """
+        pages_result = self.pdf_extractor.extract_text_by_page(pdf_path, pages)
+        if pages_result.is_failure:
+            return Result.failure(pages_result.error)  # type: ignore[arg-type]
+
         extracted_text = []
+        for page in pages_result.value or []:
+            text = page.text
 
-        try:
-            with pdfplumber.open(pdf_path) as pdf:
-                page_indices = pages if pages else range(len(pdf.pages))
+            # If direct extraction is poor, try OCR fallback
+            if not text or len(text.strip()) < self.min_text_threshold:
+                logger.debug("Page %d has low text quality, using OCR", page.page_index + 1)
+                ocr_text = self._ocr_page(pdf_path, page.page_index)
+                # Use whichever text is longer
+                if len(ocr_text) > len(text):
+                    text = ocr_text
 
-                for i in page_indices:
-                    if i >= len(pdf.pages):
-                        continue
+            if text.strip():
+                extracted_text.append(text.strip())
+            # Continue on empty pages - partial extraction is better than none
 
-                    page = pdf.pages[i]
-                    text_result = self._extract_page_text(page, i + 1)
+        if not extracted_text:
+            return Result.failure(text_extraction_error("No text could be extracted from the PDF"))
 
-                    if text_result.is_success and text_result.value and text_result.value.strip():
-                        extracted_text.append(text_result.value.strip())
-                    # Continue on page errors - partial extraction is better than none
-
-            if not extracted_text:
-                return Result.failure(text_extraction_error("No text could be extracted from the PDF"))
-
-            return Result.success(extracted_text)
-
-        except Exception as e:
-            logger.exception("Error extracting text from %s: %s", pdf_path, e)
-            return Result.from_exception(e, ErrorCode.TEXT_EXTRACTION_FAILED, retryable=True)
+        return Result.success(extracted_text)
 
     def process_document(
         self,
@@ -257,54 +262,29 @@ class DocumentEngine(IDocumentEngine):
 
         return Result.success(list(range(start - 1, end)))  # Convert to 0-based indexing
 
-    def _extract_page_text(self, page: pdfplumber.page.Page, page_num: int) -> Result[str]:
-        """Extract text from a single page with OCR fallback."""
-        try:
-            # Try direct text extraction first
-            text = page.extract_text()
-
-            # If direct extraction is poor, try OCR fallback
-            if not text or len(text.strip()) < self.min_text_threshold:
-                logger.debug("Page %d has low text quality, using OCR", page_num)
-                ocr_result = self._ocr_page(page)
-
-                if ocr_result.is_success and ocr_result.value is not None:
-                    ocr_text = ocr_result.value
-                    # Use whichever text is longer
-                    if len(ocr_text) > len(text or ""):
-                        text = ocr_text
-
-            return Result.success(text or "")
-
-        except Exception as e:
-            return Result.from_exception(e, ErrorCode.TEXT_EXTRACTION_FAILED, retryable=True)
-
-    def _ocr_page(self, page: pdfplumber.page.Page) -> Result[str]:
-        """Perform OCR on a single PDF page."""
+    def _ocr_page(self, pdf_path: str, page_index: int) -> str:
+        """Perform OCR on a single PDF page, returning empty text on any failure."""
         temp_image_path = None
 
         try:
-            # Convert page to high-resolution image
-            img = page.to_image(resolution=300).original
+            image_result = self.pdf_extractor.render_page_image(pdf_path, page_index)
+            if image_result.is_failure or image_result.value is None:
+                logger.warning("Page image rendering failed: %s", image_result.error)
+                return ""
 
-            # Save as temporary PNG file
-            with io.BytesIO() as temp_buffer:
-                img.save(temp_buffer, format="PNG")
-                image_bytes = temp_buffer.getvalue()
-
-            temp_image_path = self.file_manager.save_temp_file(image_bytes, suffix=".png")
+            temp_image_path = self.file_manager.save_temp_file(image_result.value, suffix=".png")
 
             # Perform OCR using the provider
             ocr_result = self.ocr_provider.perform_ocr(temp_image_path)
             if ocr_result.is_success:
-                return Result.success(ocr_result.value or "")
+                return ocr_result.value or ""
             else:
                 logger.warning("OCR provider failed: %s", ocr_result.error)
-                return Result.success("")  # Return empty string on OCR failure, not an error
+                return ""
 
         except Exception as e:
             logger.exception("OCR failed for page: %s", e)
-            return Result.success("")  # Return empty string on failure
+            return ""
 
         finally:
             # Clean up temporary file

--- a/domain/interfaces.py
+++ b/domain/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from .errors import Result
-from .models import PageRange, PDFInfo, ProcessingRequest, TimedAudioResult
+from .models import PageRange, PDFInfo, PdfPageText, ProcessingRequest, TimedAudioResult
 
 # --- Core Service Interfaces ---
 
@@ -66,6 +66,22 @@ class IOCRProvider(ABC):
     @abstractmethod
     def validate_range(self, pdf_path: str, page_range: PageRange) -> dict[str, Any]:
         """Validate page range against PDF document."""
+
+
+class IPdfTextExtractor(ABC):
+    """Interface for extracting text and page images from PDF documents."""
+
+    @abstractmethod
+    def extract_text_by_page(self, pdf_path: str, pages: list[int] | None = None) -> Result[list[PdfPageText]]:
+        """Extract raw text for the requested 0-based page indices (all pages if None).
+
+        Out-of-range indices are skipped; a page whose extraction fails yields
+        empty text so callers can decide on a fallback (e.g. OCR).
+        """
+
+    @abstractmethod
+    def render_page_image(self, pdf_path: str, page_index: int, resolution: int = 300) -> Result[bytes]:
+        """Render a single 0-based page as PNG bytes (for OCR fallback)."""
 
 
 class ITTSEngine(ABC):

--- a/domain/models.py
+++ b/domain/models.py
@@ -57,6 +57,14 @@ class PDFInfo:
 
 
 @dataclass(frozen=True)
+class PdfPageText:
+    """Raw text extracted from a single PDF page."""
+
+    page_index: int  # 0-based
+    text: str
+
+
+@dataclass(frozen=True)
 class FileInfo:
     """Information about a managed file."""
 

--- a/infrastructure/pdf/__init__.py
+++ b/infrastructure/pdf/__init__.py
@@ -1,0 +1,1 @@
+# infrastructure/pdf - PDF text extraction adapters

--- a/infrastructure/pdf/pdfplumber_text_extractor.py
+++ b/infrastructure/pdf/pdfplumber_text_extractor.py
@@ -1,0 +1,69 @@
+# infrastructure/pdf/pdfplumber_text_extractor.py - pdfplumber adapter for IPdfTextExtractor
+"""PDF text extraction backed by pdfplumber.
+
+Implements the domain's IPdfTextExtractor interface so the domain layer stays
+free of external library imports. All errors are returned as Result[T].
+"""
+
+import io
+import logging
+
+import pdfplumber
+
+from domain.errors import ErrorCode, Result, text_extraction_error
+from domain.interfaces import IPdfTextExtractor
+from domain.models import PdfPageText
+
+logger = logging.getLogger(__name__)
+
+
+class PdfPlumberTextExtractor(IPdfTextExtractor):
+    """Extracts text and page images from PDFs using pdfplumber."""
+
+    def extract_text_by_page(self, pdf_path: str, pages: list[int] | None = None) -> Result[list[PdfPageText]]:
+        """Extract raw text for the requested 0-based pages (all pages if None).
+
+        Out-of-range indices are skipped. A page whose extraction throws yields
+        empty text instead of failing the whole document, so the caller can
+        fall back to OCR for that page.
+        """
+        try:
+            with pdfplumber.open(pdf_path) as pdf:
+                page_indices = pages if pages else range(len(pdf.pages))
+
+                extracted: list[PdfPageText] = []
+                for i in page_indices:
+                    if not 0 <= i < len(pdf.pages):
+                        continue
+                    try:
+                        text = pdf.pages[i].extract_text() or ""
+                    except Exception:
+                        logger.warning("Text extraction failed for page %d of %s", i + 1, pdf_path, exc_info=True)
+                        text = ""
+                    extracted.append(PdfPageText(page_index=i, text=text))
+
+                return Result.success(extracted)
+
+        except Exception as e:
+            logger.exception("Error opening PDF %s: %s", pdf_path, e)
+            return Result.from_exception(e, ErrorCode.TEXT_EXTRACTION_FAILED, retryable=True)
+
+    def render_page_image(self, pdf_path: str, page_index: int, resolution: int = 300) -> Result[bytes]:
+        """Render a single 0-based page as PNG bytes.
+
+        Reopens the document per call; acceptable because rendering is only
+        used for the occasional OCR-fallback page and OCR dominates the cost.
+        """
+        try:
+            with pdfplumber.open(pdf_path) as pdf:
+                if not 0 <= page_index < len(pdf.pages):
+                    return Result.failure(text_extraction_error(f"Page index {page_index} out of range for {pdf_path}"))
+
+                img = pdf.pages[page_index].to_image(resolution=resolution).original
+                with io.BytesIO() as buffer:
+                    img.save(buffer, format="PNG")
+                    return Result.success(buffer.getvalue())
+
+        except Exception as e:
+            logger.exception("Error rendering page %d of %s: %s", page_index, pdf_path, e)
+            return Result.from_exception(e, ErrorCode.TEXT_EXTRACTION_FAILED, retryable=True)

--- a/infrastructure/pdf/pdfplumber_text_extractor.py
+++ b/infrastructure/pdf/pdfplumber_text_extractor.py
@@ -29,7 +29,7 @@ class PdfPlumberTextExtractor(IPdfTextExtractor):
         """
         try:
             with pdfplumber.open(pdf_path) as pdf:
-                page_indices = pages if pages else range(len(pdf.pages))
+                page_indices = pages if pages is not None else range(len(pdf.pages))
 
                 extracted: list[PdfPageText] = []
                 for i in page_indices:

--- a/tests/infrastructure/pdf/test_pdfplumber_text_extractor.py
+++ b/tests/infrastructure/pdf/test_pdfplumber_text_extractor.py
@@ -58,6 +58,16 @@ class TestExtractTextByPage:
         assert result.value == [PdfPageText(page_index=0, text="only page")]
 
     @patch("pdfplumber.open")
+    def test_empty_page_list_extracts_nothing(self, mock_open):
+        """An explicit empty page list must extract no pages, not the whole document."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf(["a", "b"])
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf", pages=[])
+
+        assert result.is_success
+        assert result.value == []
+
+    @patch("pdfplumber.open")
     def test_none_text_becomes_empty_string(self, mock_open):
         """Should normalize None from extract_text() to an empty string."""
         mock_open.return_value.__enter__.return_value = make_mock_pdf([None])

--- a/tests/infrastructure/pdf/test_pdfplumber_text_extractor.py
+++ b/tests/infrastructure/pdf/test_pdfplumber_text_extractor.py
@@ -1,0 +1,133 @@
+"""Tests for the pdfplumber-backed IPdfTextExtractor adapter."""
+
+from unittest.mock import MagicMock, Mock, patch
+
+from domain.models import PdfPageText
+from infrastructure.pdf.pdfplumber_text_extractor import PdfPlumberTextExtractor
+
+
+def make_mock_pdf(page_texts: list[str | None]) -> MagicMock:
+    """Build a mock pdfplumber PDF whose pages return the given texts."""
+    mock_pdf = MagicMock()
+    pages = []
+    for text in page_texts:
+        page = Mock()
+        page.extract_text.return_value = text
+        pages.append(page)
+    mock_pdf.pages = pages
+    return mock_pdf
+
+
+class TestExtractTextByPage:
+    """Tests for extract_text_by_page."""
+
+    @patch("pdfplumber.open")
+    def test_extracts_all_pages_by_default(self, mock_open):
+        """Should extract every page when no page list is given."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf(["page one", "page two"])
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf")
+
+        assert result.is_success
+        assert result.value == [
+            PdfPageText(page_index=0, text="page one"),
+            PdfPageText(page_index=1, text="page two"),
+        ]
+
+    @patch("pdfplumber.open")
+    def test_extracts_requested_pages_only(self, mock_open):
+        """Should extract only the requested page indices."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf(["a", "b", "c"])
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf", pages=[0, 2])
+
+        assert result.is_success
+        assert result.value == [
+            PdfPageText(page_index=0, text="a"),
+            PdfPageText(page_index=2, text="c"),
+        ]
+
+    @patch("pdfplumber.open")
+    def test_skips_out_of_range_pages(self, mock_open):
+        """Should silently skip out-of-range indices."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf(["only page"])
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf", pages=[0, 5, -1])
+
+        assert result.is_success
+        assert result.value == [PdfPageText(page_index=0, text="only page")]
+
+    @patch("pdfplumber.open")
+    def test_none_text_becomes_empty_string(self, mock_open):
+        """Should normalize None from extract_text() to an empty string."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf([None])
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf")
+
+        assert result.is_success
+        assert result.value == [PdfPageText(page_index=0, text="")]
+
+    @patch("pdfplumber.open")
+    def test_page_extraction_failure_yields_empty_text(self, mock_open):
+        """A failing page should yield empty text, not fail the document."""
+        mock_pdf = make_mock_pdf(["good page"])
+        broken_page = Mock()
+        broken_page.extract_text.side_effect = Exception("corrupt page")
+        mock_pdf.pages = [broken_page, *mock_pdf.pages]
+        mock_open.return_value.__enter__.return_value = mock_pdf
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("test.pdf")
+
+        assert result.is_success
+        assert result.value == [
+            PdfPageText(page_index=0, text=""),
+            PdfPageText(page_index=1, text="good page"),
+        ]
+
+    @patch("pdfplumber.open")
+    def test_open_failure_returns_error(self, mock_open):
+        """A document that cannot be opened should return a failure Result."""
+        mock_open.side_effect = Exception("not a PDF")
+
+        result = PdfPlumberTextExtractor().extract_text_by_page("bad.pdf")
+
+        assert result.is_failure
+
+
+class TestRenderPageImage:
+    """Tests for render_page_image."""
+
+    @patch("pdfplumber.open")
+    def test_renders_page_as_png_bytes(self, mock_open):
+        """Should render the page at 300dpi and return PNG bytes."""
+        mock_pdf = make_mock_pdf(["page"])
+        mock_img = Mock()
+        mock_img.save.side_effect = lambda buffer, format: buffer.write(b"png-bytes")
+        mock_pdf.pages[0].to_image.return_value.original = mock_img
+        mock_open.return_value.__enter__.return_value = mock_pdf
+
+        result = PdfPlumberTextExtractor().render_page_image("test.pdf", 0)
+
+        assert result.is_success
+        assert result.value == b"png-bytes"
+        mock_pdf.pages[0].to_image.assert_called_once_with(resolution=300)
+
+    @patch("pdfplumber.open")
+    def test_out_of_range_page_returns_error(self, mock_open):
+        """An out-of-range page index should return a failure Result."""
+        mock_open.return_value.__enter__.return_value = make_mock_pdf(["page"])
+
+        result = PdfPlumberTextExtractor().render_page_image("test.pdf", 3)
+
+        assert result.is_failure
+
+    @patch("pdfplumber.open")
+    def test_render_failure_returns_error(self, mock_open):
+        """A rendering exception should return a failure Result."""
+        mock_pdf = make_mock_pdf(["page"])
+        mock_pdf.pages[0].to_image.side_effect = Exception("render boom")
+        mock_open.return_value.__enter__.return_value = mock_pdf
+
+        result = PdfPlumberTextExtractor().render_page_image("test.pdf", 0)
+
+        assert result.is_failure

--- a/tests/unit/test_domain_purity.py
+++ b/tests/unit/test_domain_purity.py
@@ -1,0 +1,43 @@
+"""Regression test: the domain layer must not depend on anything outside itself.
+
+The architecture docs claim domain/ has no external dependencies; this test
+enforces it, so violations like the old direct pdfplumber import (issue #36)
+cannot creep back in.
+"""
+
+import ast
+from pathlib import Path
+import sys
+
+import pytest
+
+DOMAIN_DIR = Path("domain")
+
+
+def _module_root(module_name: str) -> str:
+    return module_name.split(".")[0]
+
+
+@pytest.mark.unit
+class TestDomainPurity:
+    """Ensure hexagonal architecture boundaries are respected in domain/."""
+
+    def test_domain_imports_only_stdlib_and_domain(self) -> None:
+        """Every import in domain/ must be stdlib or domain-internal."""
+        allowed_roots = set(sys.stdlib_module_names) | {"domain"}
+        violations: list[str] = []
+
+        for py_file in sorted(DOMAIN_DIR.rglob("*.py")):
+            tree = ast.parse(py_file.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if _module_root(alias.name) not in allowed_roots:
+                            violations.append(f"{py_file}:{node.lineno}: import {alias.name}")
+                elif isinstance(node, ast.ImportFrom):
+                    if node.level > 0:  # Relative imports stay within domain/
+                        continue
+                    if _module_root(node.module or "") not in allowed_roots:
+                        violations.append(f"{py_file}:{node.lineno}: from {node.module} import ...")
+
+        assert violations == [], "External imports found in domain/:\n" + "\n".join(violations)


### PR DESCRIPTION
Closes #36.

## Problem

`domain/document/document_engine.py` imported `pdfplumber` directly — the single exception to the hexagonal rule that OCR, TTS, and LLM all follow, making the README's "domain has no external deps" claim false.

## Changes

- **New domain interface** `IPdfTextExtractor` with two methods: `extract_text_by_page(pdf_path, pages)` returning `PdfPageText` records (new frozen dataclass in `domain/models.py`), and `render_page_image(pdf_path, page_index)` returning PNG bytes for the OCR fallback.
- **New adapter** `infrastructure/pdf/pdfplumber_text_extractor.py` implementing it — all pdfplumber mechanics live there now, errors returned as `Result[T]`.
- **DocumentEngine** receives the extractor via constructor injection. The domain keeps what is genuinely domain logic: the low-quality-text threshold, the OCR-fallback decision, and pick-whichever-text-is-longer. `_ocr_page` now takes `(pdf_path, page_index)` and returns a plain `str` (it always returned a success Result before — dead ceremony).
- **Container**: `IPdfTextExtractor → PdfPlumberTextExtractor` registered and injected.

### Behavior note

A page whose text extraction throws previously got dropped with no OCR attempt; it now yields empty text and therefore gets the OCR fallback — strictly better recovery for partially corrupt PDFs.

## Regression guard

New `tests/unit/test_domain_purity.py` walks every file in `domain/` with `ast` and asserts all imports are stdlib or domain-internal — the violation class this issue is about can't creep back in silently.

## Tests

9 new adapter tests (mocked pdfplumber, mirroring the OCR provider test style) + the purity test. Full suite: 445 passed; ruff, format, strict mypy clean.