### PR TITLE
refactor: bounded worker pool for background processing; keep page range on result page

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ silly_PDF2WAV/
 - `GET /api/timing/<filename>` — Timing metadata as JSON
 - `GET /api/progress/<operation_id>` — Processing progress
 
+## Design Constraints
+
+This is a single-user home app, and the background-processing model is deliberately simple:
+
+- Uploads are processed by a bounded in-process worker pool (`performance.max_concurrent_operations` in `config.yaml`, default 2). Uploads beyond the cap queue up rather than being rejected.
+- Progress and results live in memory only. A restart loses in-flight work and pending result pages, even though finished audio files remain on disk.
+- Run it as a single process (the Flask dev server). Multiple WSGI workers would each get their own progress store, so progress polling would 404 at random.
+
 ## Testing
 
 ```bash

--- a/app_factory.py
+++ b/app_factory.py
@@ -4,6 +4,7 @@ This module provides the Flask application factory that creates and configures
 the Flask app with all dependencies properly injected, eliminating global state.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
 
@@ -62,12 +63,20 @@ def create_app(config_path: Path | None = None) -> Flask:
             check_interval_seconds=300,
         )
 
+    # Bounded worker pool for background document processing: caps concurrent
+    # operations at the configured limit, uploads beyond it queue up.
+    background_executor = ThreadPoolExecutor(
+        max_workers=app_config.performance.max_concurrent_operations,
+        thread_name_prefix="pdf2wav-worker",
+    )
+
     # Create application context
     app_context = ApplicationContext(
         config=app_config,
         service_container=service_container,
         logger_factory=logger_factory,
         progress_store=service_container.get(ThreadSafeProgressStore),
+        background_executor=background_executor,
         cleanup_scheduler=cleanup_scheduler,
     )
 

--- a/app_factory.py
+++ b/app_factory.py
@@ -4,6 +4,7 @@ This module provides the Flask application factory that creates and configures
 the Flask app with all dependencies properly injected, eliminating global state.
 """
 
+import atexit
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import replace
 from pathlib import Path
@@ -69,6 +70,9 @@ def create_app(config_path: Path | None = None) -> Flask:
         max_workers=app_config.performance.max_concurrent_operations,
         thread_name_prefix="pdf2wav-worker",
     )
+    # On process exit: let in-flight conversions finish, but drop queued ones
+    # instead of draining the whole queue before shutdown completes.
+    atexit.register(background_executor.shutdown, wait=False, cancel_futures=True)
 
     # Create application context
     app_context = ApplicationContext(

--- a/application/config/processing_configs.py
+++ b/application/config/processing_configs.py
@@ -41,3 +41,4 @@ class PerformanceConfig:
 
     enable_async_audio: bool = True
     audio_concurrent_chunks: int = 4
+    max_concurrent_operations: int = 2

--- a/application/config/system_config.py
+++ b/application/config/system_config.py
@@ -341,6 +341,9 @@ class SystemConfig:
         return PerformanceConfig(
             enable_async_audio=cls._parse_bool_value(get_config("performance.enable_async_audio", True), True),
             audio_concurrent_chunks=cls._parse_int_value(get_config("audio.concurrent_chunks", 4), 4, 1, 20),
+            max_concurrent_operations=cls._parse_int_value(
+                get_config("performance.max_concurrent_operations", 2), 2, 1, 8
+            ),
         )
 
     @classmethod

--- a/application/context/application_context.py
+++ b/application/context/application_context.py
@@ -4,6 +4,7 @@ This module provides the ApplicationContext class which encapsulates all applica
 dependencies and eliminates global state, following hexagonal architecture principles.
 """
 
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 import logging
 from typing import Protocol
@@ -38,6 +39,7 @@ class ApplicationContext:
     service_container: ServiceContainer
     logger_factory: LoggerFactory
     progress_store: ThreadSafeProgressStore
+    background_executor: ThreadPoolExecutor
     cleanup_scheduler: FileCleanupScheduler | None = None
 
     @property

--- a/application/services/document_service.py
+++ b/application/services/document_service.py
@@ -144,6 +144,7 @@ class DocumentProcessingService:
                     "base_filename": base_filename,
                     "original_filename": original_filename,
                     "audio_result": audio_result,
+                    "page_range": page_range,
                 },
             )
 

--- a/routes.py
+++ b/routes.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 from pathlib import Path
-import threading
 import time
 from typing import Any
 import uuid
@@ -250,8 +249,8 @@ def register_routes(app: Flask) -> None:
         if not audio_result:
             return "No processing result available", 500
 
-        # We need to reconstruct the page range - for now use default
-        page_range = PageRange(start_page=None, end_page=None)  # Default to all pages
+        # Page range travels through result_data so the result page reflects the selection
+        page_range = result_data.get("page_range") or PageRange(start_page=None, end_page=None)
 
         # Check if this was a timing-enabled operation
         enable_timing = progress.stage in ["complete"] and audio_result.timing_data is not None
@@ -370,24 +369,21 @@ def register_routes(app: Flask) -> None:
         # Convert form data to dict (Flask objects don't work in threads)
         form_data = dict(request.form)
 
-        # Start background processing with app context
+        # Submit to the bounded worker pool; uploads beyond the concurrency cap queue up
         from flask import current_app
 
-        thread = threading.Thread(
-            target=background_process_document,
-            args=(
-                operation_id,
-                form_data,
-                str(saved_path),
-                original_filename,
-                enable_timing,
-                get_app_context(),
-                current_app._get_current_object(),  # type: ignore[attr-defined]
-            ),
-            daemon=True,
+        context = get_app_context()
+        context.background_executor.submit(
+            background_process_document,
+            operation_id,
+            form_data,
+            str(saved_path),
+            original_filename,
+            enable_timing,
+            context,
+            current_app._get_current_object(),  # type: ignore[attr-defined]
         )
-        thread.start()
-        route_logger.info("Background processing started: op=%s", operation_id[:8])
+        route_logger.info("Background processing queued: op=%s", operation_id[:8])
 
         # Return processing page immediately
         return render_template("processing.html", operation_id=operation_id, enable_timing=enable_timing)

--- a/routes.py
+++ b/routes.py
@@ -4,7 +4,9 @@ This module provides all route handlers that use ApplicationContext for
 dependency injection, eliminating global state.
 """
 
+from concurrent.futures import Future
 import contextlib
+from functools import partial
 import json
 import logging
 import os
@@ -75,6 +77,26 @@ def background_process_document(
             get_progress_store().update(
                 operation_id, "error", 0, "Processing failed unexpectedly", is_error=True, error_message=enhanced_error
             )
+
+
+def handle_background_completion(
+    future: Future[None], operation_id: str, progress_store: ThreadSafeProgressStore
+) -> None:
+    """Surface exceptions that escaped background_process_document's own handling.
+
+    Without this, an exception raised outside the wrapper's try block would sit
+    silently on the discarded Future while the operation hangs at its last
+    progress state.
+    """
+    if future.cancelled():
+        return
+    exc = future.exception()
+    if exc is None:
+        return
+    logging.getLogger(__name__).error("Uncaught error in background operation %s", operation_id[:8], exc_info=exc)
+    progress_store.update(
+        operation_id, "error", 0, "Processing failed unexpectedly", is_error=True, error_message=str(exc)
+    )
 
 
 def get_app_context() -> ApplicationContext:
@@ -373,7 +395,7 @@ def register_routes(app: Flask) -> None:
         from flask import current_app
 
         context = get_app_context()
-        context.background_executor.submit(
+        future = context.background_executor.submit(
             background_process_document,
             operation_id,
             form_data,
@@ -382,6 +404,9 @@ def register_routes(app: Flask) -> None:
             enable_timing,
             context,
             current_app._get_current_object(),  # type: ignore[attr-defined]
+        )
+        future.add_done_callback(
+            partial(handle_background_completion, operation_id=operation_id, progress_store=context.progress_store)
         )
         route_logger.info("Background processing queued: op=%s", operation_id[:8])
 

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -493,3 +493,64 @@ class TestBackgroundProcessingModel:
 
         assert response.status_code == 200
         assert "pages" not in response.get_data(as_text=True).lower().split("doc.pdf")[1][:30]
+
+
+class TestBackgroundCompletionHandler:
+    """Tests for the Future done-callback that surfaces escaped exceptions."""
+
+    def test_escaped_exception_marks_operation_failed(self) -> None:
+        """An exception stored on the Future must reach the progress store."""
+        from concurrent.futures import Future
+
+        from application.services.progress_store import ThreadSafeProgressStore
+        from routes import handle_background_completion
+
+        store = ThreadSafeProgressStore()
+        store.update("op-boom", "processing", 50, "Working")
+
+        future: Future[None] = Future()
+        future.set_exception(RuntimeError("worker exploded"))
+        handle_background_completion(future, "op-boom", store)
+
+        progress = store.get("op-boom")
+        assert progress is not None
+        assert progress.is_error is True
+        assert progress.error_message is not None
+        assert "worker exploded" in progress.error_message
+
+    def test_successful_future_leaves_progress_untouched(self) -> None:
+        """A clean completion must not overwrite the final progress state."""
+        from concurrent.futures import Future
+
+        from application.services.progress_store import ThreadSafeProgressStore
+        from routes import handle_background_completion
+
+        store = ThreadSafeProgressStore()
+        store.update("op-ok", "complete", 100, "Done", is_complete=True)
+
+        future: Future[None] = Future()
+        future.set_result(None)
+        handle_background_completion(future, "op-ok", store)
+
+        progress = store.get("op-ok")
+        assert progress is not None
+        assert progress.is_error is False
+        assert progress.stage == "complete"
+
+    def test_cancelled_future_is_ignored(self) -> None:
+        """A cancelled queued upload must not be reported as an error."""
+        from concurrent.futures import Future
+
+        from application.services.progress_store import ThreadSafeProgressStore
+        from routes import handle_background_completion
+
+        store = ThreadSafeProgressStore()
+        store.update("op-cancelled", "starting", 0, "Queued")
+
+        future: Future[None] = Future()
+        future.cancel()
+        handle_background_completion(future, "op-cancelled", store)
+
+        progress = store.get("op-cancelled")
+        assert progress is not None
+        assert progress.is_error is False

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -21,7 +21,7 @@ from application.config.processing_configs import LLMConfig, OCRConfig, Performa
 from application.config.system_config import SystemConfig
 from domain.config.tts_config import PiperConfig, TTSConfig, TTSEngine
 from domain.errors import Result
-from domain.models import PDFInfo
+from domain.models import PageRange, PDFInfo, TimedAudioResult
 from routes import register_routes
 
 # === Flask App Test Fixtures ===
@@ -438,3 +438,58 @@ class TestEndToEndPDFConversion:
             json_data = api_response.get_json()
             assert "total_duration" in json_data, "API should return timing data"
             assert "text_segments" in json_data, "API should include text segments"
+
+
+class TestBackgroundProcessingModel:
+    """Tests for the bounded worker pool and result-page state handling."""
+
+    def test_background_executor_uses_configured_cap(self, test_app: Flask, flask_test_config: SystemConfig) -> None:
+        """The app's worker pool must honor performance.max_concurrent_operations."""
+        context = test_app.config["APP_CONTEXT"]
+        expected = flask_test_config.performance.max_concurrent_operations
+        assert context.background_executor._max_workers == expected
+
+    def test_result_page_shows_selected_page_range(self, test_app: Flask, client: FlaskClient) -> None:
+        """/result must display the page range the user selected, not the full document."""
+        context = test_app.config["APP_CONTEXT"]
+        context.progress_store.update(
+            "op-range",
+            "complete",
+            100,
+            "Processing complete!",
+            is_complete=True,
+            result_data={
+                "base_filename": "doc",
+                "original_filename": "doc.pdf",
+                "audio_result": TimedAudioResult(audio_files=["doc.mp3"], combined_mp3=None),
+                "page_range": PageRange(start_page=2, end_page=5),
+            },
+        )
+
+        response = client.get("/result/op-range")
+
+        assert response.status_code == 200
+        assert "pages 2-5" in response.get_data(as_text=True)
+
+    def test_result_page_defaults_to_full_document_without_page_range(
+        self, test_app: Flask, client: FlaskClient
+    ) -> None:
+        """Older result_data without a page_range entry must still render."""
+        context = test_app.config["APP_CONTEXT"]
+        context.progress_store.update(
+            "op-full",
+            "complete",
+            100,
+            "Processing complete!",
+            is_complete=True,
+            result_data={
+                "base_filename": "doc",
+                "original_filename": "doc.pdf",
+                "audio_result": TimedAudioResult(audio_files=["doc.mp3"], combined_mp3=None),
+            },
+        )
+
+        response = client.get("/result/op-full")
+
+        assert response.status_code == 200
+        assert "pages" not in response.get_data(as_text=True).lower().split("doc.pdf")[1][:30]

--- a/tests/unit/test_system_config_yaml.py
+++ b/tests/unit/test_system_config_yaml.py
@@ -78,6 +78,28 @@ class TestSystemConfigYAMLLoading:
         assert config.cleanup.enabled is False
         assert config.cleanup.max_file_age_hours == 48.0
 
+    def test_from_yaml_max_concurrent_operations(self, tmp_path: Path):
+        """Should parse the background-processing concurrency cap."""
+        config_data = {"tts": {"engine": "piper"}, "performance": {"max_concurrent_operations": 4}}
+
+        config_file = _write_yaml_config(tmp_path, config_data)
+        config = SystemConfig.from_yaml(config_file)
+        assert config.performance.max_concurrent_operations == 4
+
+    def test_from_yaml_max_concurrent_operations_default(self, tmp_path: Path):
+        """Should default the concurrency cap to 2."""
+        config_file = _write_yaml_config(tmp_path, {"tts": {"engine": "piper"}})
+        config = SystemConfig.from_yaml(config_file)
+        assert config.performance.max_concurrent_operations == 2
+
+    def test_from_yaml_max_concurrent_operations_out_of_range(self, tmp_path: Path):
+        """Should reject values outside the 1-8 range."""
+        config_data = {"tts": {"engine": "piper"}, "performance": {"max_concurrent_operations": 99}}
+
+        config_file = _write_yaml_config(tmp_path, config_data)
+        with pytest.raises(ValueError, match="<= 8"):
+            SystemConfig.from_yaml(config_file)
+
     def test_from_yaml_missing_file_raises_error(self):
         """Test that missing YAML file raises appropriate error."""
         with pytest.raises(FileNotFoundError) as exc_info:


### PR DESCRIPTION
Closes #38, closes #37.

## Concurrency cap (#38)

Each upload used to spawn a raw daemon `threading.Thread`, each of which runs concurrent TTS work — no ceiling anywhere. Now:

- `ApplicationContext` owns a shared `ThreadPoolExecutor` (`pdf2wav-worker` threads), created in `app_factory` from the new `performance.max_concurrent_operations` config (default 2, validated range 1–8).
- `_handle_upload` submits to the pool; uploads beyond the cap queue up rather than being rejected — the progress page just shows the initial 'Upload received' state until a worker picks the job up.
- Side benefit: worker threads are non-daemon, so a shutdown waits for the in-flight conversion instead of killing it mid-write.

## Page range on the result page (#37)

`show_result` reconstructed the page range as a hardcoded full-document default, silently dropping the user's selection. The `PageRange` now travels through `result_data` (stored on completion in `DocumentProcessingService`) and `/result/<id>` renders '(pages X-Y)' correctly. Older entries without the key still render as full document.

## Documented ceilings

New README **Design Constraints** section states what stays deliberately simple for a single-user home app: in-memory progress/results (lost on restart), single-process only (multiple WSGI workers would each get their own store). A persistent task queue is explicitly out of scope.

## Tests

- Config parsing: value, default, and out-of-range rejection for `max_concurrent_operations`.
- Integration: executor honors the configured cap; `/result` shows the selected range; legacy `result_data` without a range still renders.

Full suite: 452 passed; ruff, format, strict mypy clean.