### PR TITLE
fix: gate /admin endpoints and deduplicate file cleanup logic

### DIFF
--- a/application/config/app_configs.py
+++ b/application/config/app_configs.py
@@ -11,3 +11,15 @@ class FlaskConfig:
     debug: bool = True
     host: str = "127.0.0.1"  # Secure default: localhost only
     port: int = 5000
+
+
+@dataclass(frozen=True)
+class AdminConfig:
+    """Gating for the /admin/* endpoints.
+
+    Disabled by default: the endpoints expose filesystem details and can delete
+    generated audio, which is unsafe when the server binds to a non-localhost host.
+    """
+
+    enabled: bool = False
+    token: str | None = None

--- a/application/config/system_config.py
+++ b/application/config/system_config.py
@@ -53,6 +53,10 @@ ocr:                    # OCRConfig - Tesseract settings
 llm:                    # LLMConfig - LLM provider settings
   model_name, max_tokens, temperature
 
+admin:                  # AdminConfig - /admin endpoint gating
+  enabled               # Default false; /admin/* returns 404 when disabled
+                        # Optional token via secrets.admin_token (X-Admin-Token header)
+
 Dependencies
 ------------
 - tts.engine determines which of piper/gemini config is active
@@ -76,7 +80,7 @@ import yaml
 
 from domain.config.tts_config import GeminiConfig, PiperConfig, TTSConfig, TTSEngine
 
-from .app_configs import FlaskConfig
+from .app_configs import AdminConfig, FlaskConfig
 from .file_configs import FileCleanupConfig, FileConfig
 from .logging_config import LoggingConfig
 from .processing_configs import LLMConfig, OCRConfig, PerformanceConfig, TextProcessingConfig
@@ -109,6 +113,9 @@ class SystemConfig:
 
     # Logging configuration (default INFO, auto-derived from flask.debug in from_yaml)
     logging_config: LoggingConfig = field(default_factory=LoggingConfig)
+
+    # Admin endpoint gating (disabled by default)
+    admin: AdminConfig = field(default_factory=AdminConfig)
 
     # System-level settings
     project_root: str = ""
@@ -145,6 +152,7 @@ class SystemConfig:
         ocr_config = cls._parse_ocr_config(get_config)
         llm_config = cls._parse_llm_config(get_config)
         logging_config = cls._parse_logging_config(get_config, flask_config)
+        admin_config = cls._parse_admin_config(get_config)
 
         # Get project root
         project_root = str(get_config("system.project_root", ""))
@@ -162,6 +170,7 @@ class SystemConfig:
             gemini=gemini_config,
             piper=piper_config,
             logging_config=logging_config,
+            admin=admin_config,
             project_root=project_root,
         )
 
@@ -353,6 +362,14 @@ class SystemConfig:
             debug=cls._parse_bool_value(get_config("app.debug", True), True),
             host=cls._parse_string_value(get_config("app.host", "127.0.0.1"), "127.0.0.1"),
             port=cls._parse_int_value(get_config("app.port", 5000), 5000, 1000, 65535),
+        )
+
+    @classmethod
+    def _parse_admin_config(cls, get_config: ConfigAccessor) -> AdminConfig:
+        """Parse admin endpoint gating configuration."""
+        return AdminConfig(
+            enabled=cls._parse_bool_value(get_config("admin.enabled", False), False),
+            token=cls._parse_optional_string_value(get_config("secrets.admin_token", None)),
         )
 
     @classmethod

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -78,11 +78,20 @@ app:
   host: "127.0.0.1"
   port: 5000
 
+# Admin Endpoints (/admin/*)
+# Disabled by default: they expose filesystem details and can delete generated
+# audio. Only enable on a trusted host; set an admin_token under secrets if the
+# server is reachable by others (send it as the X-Admin-Token header).
+admin:
+  enabled: false
+
 # Secrets and API Keys
 secrets:
   # Required for Text Cleaning and Gemini TTS
   # Get one at: https://aistudio.google.com/app/apikey
   google_ai_api_key: "YOUR_GOOGLE_AI_API_KEY"
+  # Optional: required X-Admin-Token header value for /admin/* when set
+  # admin_token: "choose-a-long-random-string"
 
 # OCR Settings (Tesseract)
 ocr:

--- a/domain/interfaces.py
+++ b/domain/interfaces.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 from .errors import Result
-from .models import PageRange, PDFInfo, PdfPageText, ProcessingRequest, TimedAudioResult
+from .models import CleanupStats, PageRange, PDFInfo, PdfPageText, ProcessingRequest, TimedAudioResult
 
 # --- Core Service Interfaces ---
 
@@ -31,6 +31,10 @@ class IFileManager(ABC):
     @abstractmethod
     def get_output_dir(self) -> str:
         """Returns the path to the output directory."""
+
+    @abstractmethod
+    def cleanup_old_files(self, max_age_hours: float) -> Result[CleanupStats]:
+        """Deletes output files older than max_age_hours; fails on non-positive or non-finite age."""
 
 
 class ILLMProvider(ABC):

--- a/domain/models.py
+++ b/domain/models.py
@@ -65,6 +65,15 @@ class PdfPageText:
 
 
 @dataclass(frozen=True)
+class CleanupStats:
+    """Outcome of an age-based file cleanup pass."""
+
+    files_removed: int
+    bytes_freed: int
+    errors: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class FileInfo:
     """Information about a managed file."""
 

--- a/infrastructure/file/cleanup_scheduler.py
+++ b/infrastructure/file/cleanup_scheduler.py
@@ -64,6 +64,11 @@ class FileCleanupScheduler:
             self._stop_event.set()
             self._thread.join(timeout=5)
 
+    def run_manual_cleanup(self) -> dict[str, int]:
+        """Run one cleanup pass immediately and report how many tracked files were deleted."""
+        logger.info("Manual cleanup triggered")
+        return {"files_deleted": self._process_expired_files()}
+
     def _cleanup_job(self) -> None:
         """Main cleanup loop running in background thread."""
         while not self._stop_event.is_set():
@@ -76,8 +81,8 @@ class FileCleanupScheduler:
             # Wait for next interval, checking stop event
             self._stop_event.wait(self.check_interval_seconds)
 
-    def _process_expired_files(self) -> None:
-        """Process and remove expired files."""
+    def _process_expired_files(self) -> int:
+        """Process and remove expired files, returning the number deleted."""
         current_time = time.time()
 
         # Collect expired files under lock (fast), then delete outside lock (slow I/O)
@@ -90,7 +95,7 @@ class FileCleanupScheduler:
             }
 
         if not expired:
-            return
+            return 0
 
         # Delete files outside lock so schedule() isn't blocked by I/O
         successfully_deleted = []
@@ -108,3 +113,4 @@ class FileCleanupScheduler:
                 for filepath in successfully_deleted:
                     self._scheduled_files.pop(filepath, None)
             logger.debug("Cleanup cycle complete: %d files deleted", len(successfully_deleted))
+        return len(successfully_deleted)

--- a/infrastructure/file/file_manager.py
+++ b/infrastructure/file/file_manager.py
@@ -4,11 +4,15 @@ Handles file I/O, directory management, and temporary file creation.
 """
 
 import logging
+import math
 import os
 from pathlib import Path
 import tempfile
+import time
 
+from domain.errors import Result, configuration_error
 from domain.interfaces import IFileManager
+from domain.models import CleanupStats
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +56,37 @@ class FileManager(IFileManager):
         logger.debug("Saved output file: %s (%d bytes)", base_filename, len(content))
 
         return str(output_path)
+
+    def cleanup_old_files(self, max_age_hours: float) -> Result[CleanupStats]:
+        """Deletes files in the output directory with mtime older than max_age_hours.
+
+        Rejects non-positive and non-finite ages: a negative age would put the
+        cutoff in the future and delete every file, and NaN comparisons would
+        silently match nothing.
+        """
+        if not math.isfinite(max_age_hours) or max_age_hours <= 0:
+            return Result.failure(
+                configuration_error(f"max_age_hours must be a positive finite number, got {max_age_hours!r}")
+            )
+
+        cutoff_time = time.time() - max_age_hours * 3600
+        files_removed = 0
+        bytes_freed = 0
+        errors: list[str] = []
+
+        for filepath in Path(self.output_folder).iterdir():
+            try:
+                stat = filepath.stat()
+                if not filepath.is_file() or stat.st_mtime >= cutoff_time:
+                    continue
+                filepath.unlink()
+                files_removed += 1
+                bytes_freed += stat.st_size
+                logger.info("Cleaned up old file: %s", filepath.name)
+            except OSError as e:
+                errors.append(f"Failed to remove {filepath.name}: {e!s}")
+
+        return Result.success(CleanupStats(files_removed=files_removed, bytes_freed=bytes_freed, errors=tuple(errors)))
 
     def delete_file(self, filepath: str) -> None:
         """Deletes a file if it exists."""

--- a/routes.py
+++ b/routes.py
@@ -7,11 +7,12 @@ dependency injection, eliminating global state.
 from concurrent.futures import Future
 import contextlib
 from functools import partial
+import hmac
 import json
 import logging
+import math
 import os
 from pathlib import Path
-import time
 from typing import Any
 import uuid
 
@@ -426,9 +427,28 @@ def register_routes(app: Flask) -> None:
             return "Read-along mode is not available with Gemini TTS. Please use regular upload or switch to Piper TTS."
         return _handle_upload(enable_timing=True)
 
+    def _require_admin() -> tuple[Response, int] | None:
+        """Gate /admin endpoints: 404 while disabled, 403 on missing/wrong token.
+
+        Returning 404 when disabled hides the endpoints' existence, matching the
+        default config where the server binds to non-localhost hosts at will.
+        """
+        admin = get_app_config().admin
+        if not admin.enabled:
+            return jsonify({"error": "Not found"}), 404
+        if admin.token:
+            provided = request.headers.get("X-Admin-Token", "")
+            if not hmac.compare_digest(provided.encode(), admin.token.encode()):
+                return jsonify({"error": "Forbidden"}), 403
+        return None
+
     @app.route("/admin/file_stats")
     def get_file_stats() -> Response | tuple[Response, int]:
         """Get file management statistics (admin endpoint)."""
+        denied = _require_admin()
+        if denied is not None:
+            return denied
+
         service = get_pdf_service()
         if not is_processor_available():
             return jsonify({"error": "Service not available"}), 500
@@ -459,6 +479,10 @@ def register_routes(app: Flask) -> None:
     @app.route("/admin/cleanup", methods=["POST"])
     def manual_cleanup() -> Response | tuple[Response, int]:
         """Trigger manual file cleanup (admin endpoint)."""
+        denied = _require_admin()
+        if denied is not None:
+            return denied
+
         service = get_pdf_service()
         if not is_processor_available():
             return jsonify({"error": "Service not available"}), 500
@@ -467,30 +491,23 @@ def register_routes(app: Flask) -> None:
             if not service.has(IFileManager):
                 return jsonify({"error": "File management not available"}), 404
 
-            max_age_hours = float(request.form.get("max_age_hours", 24.0))
-            audio_dir = Path(app.config["AUDIO_FOLDER"])
-            cutoff_time = time.time() - (max_age_hours * 3600)
+            try:
+                max_age_hours = float(request.form.get("max_age_hours", 24.0))
+            except ValueError:
+                return jsonify({"error": "max_age_hours must be a number"}), 400
+            if not math.isfinite(max_age_hours) or max_age_hours <= 0:
+                return jsonify({"error": "max_age_hours must be a positive number"}), 400
 
-            removed_files = 0
-            bytes_freed = 0
-            errors: list[str] = []
+            cleanup_result = service.get(IFileManager).cleanup_old_files(max_age_hours)
+            if cleanup_result.is_failure or cleanup_result.value is None:
+                return jsonify({"error": str(cleanup_result.error)}), 500
 
-            for filepath in audio_dir.iterdir():
-                if filepath.is_file() and filepath.stat().st_mtime < cutoff_time:
-                    try:
-                        file_size = filepath.stat().st_size
-                        filepath.unlink()
-                        removed_files += 1
-                        bytes_freed += file_size
-                        get_logger("routes").info("Cleaned up old file: %s", filepath.name)
-                    except Exception as e:
-                        errors.append(f"Failed to remove {filepath.name}: {e!s}")
-
+            stats = cleanup_result.value
             result = {
-                "files_removed": removed_files,
-                "bytes_freed": bytes_freed,
-                "mb_freed": bytes_freed / (1024 * 1024),
-                "errors": errors,
+                "files_removed": stats.files_removed,
+                "bytes_freed": stats.bytes_freed,
+                "mb_freed": stats.bytes_freed / (1024 * 1024),
+                "errors": list(stats.errors),
                 "max_age_hours": max_age_hours,
             }
             return jsonify(result)
@@ -502,6 +519,10 @@ def register_routes(app: Flask) -> None:
     @app.route("/admin/cleanup_scheduler", methods=["POST"])
     def trigger_scheduler_cleanup() -> Response | tuple[Response, int]:
         """Trigger scheduler's manual cleanup."""
+        denied = _require_admin()
+        if denied is not None:
+            return denied
+
         try:
             context = get_app_context()
             scheduler = context.cleanup_scheduler
@@ -509,11 +530,7 @@ def register_routes(app: Flask) -> None:
             if scheduler is None:
                 return jsonify({"error": "Cleanup scheduler not available"}), 500
 
-            if hasattr(scheduler, "run_manual_cleanup"):
-                result = scheduler.run_manual_cleanup()
-                return jsonify(result)
-            else:
-                return jsonify({"error": "Manual cleanup not supported by scheduler"}), 404
+            return jsonify(scheduler.run_manual_cleanup())
 
         except Exception as e:
             get_logger("routes").error("Scheduler cleanup error: %s", str(e))
@@ -522,6 +539,10 @@ def register_routes(app: Flask) -> None:
     @app.route("/admin/test")
     def test_admin() -> Response | tuple[Response, int]:
         """Test endpoint to check what's available."""
+        denied = _require_admin()
+        if denied is not None:
+            return denied
+
         try:
             service = get_pdf_service()
 

--- a/tests/infrastructure/file/test_cleanup_scheduler.py
+++ b/tests/infrastructure/file/test_cleanup_scheduler.py
@@ -627,3 +627,28 @@ class TestIntegration:
             )
 
             assert mock_file_manager.delete_file.call_count == expired_count
+
+
+class TestRunManualCleanup:
+    """Test the on-demand cleanup entry point used by /admin/cleanup_scheduler."""
+
+    def test_deletes_expired_files_and_reports_count(self, scheduler, mock_file_manager, mock_time):
+        """Should run one pass immediately and report how many files were deleted."""
+        mock_time.return_value = 1000.0
+        scheduler.schedule("/audio/expired.wav")
+        mock_time.return_value = 1000.0 + scheduler.max_file_age_seconds + 1
+
+        result = scheduler.run_manual_cleanup()
+
+        assert result == {"files_deleted": 1}
+        mock_file_manager.delete_file.assert_called_once_with("/audio/expired.wav")
+
+    def test_reports_zero_when_nothing_expired(self, scheduler, mock_file_manager, mock_time):
+        """Should report zero deletions when no tracked file has expired."""
+        mock_time.return_value = 1000.0
+        scheduler.schedule("/audio/fresh.wav")
+
+        result = scheduler.run_manual_cleanup()
+
+        assert result == {"files_deleted": 0}
+        mock_file_manager.delete_file.assert_not_called()

--- a/tests/infrastructure/file/test_file_manager.py
+++ b/tests/infrastructure/file/test_file_manager.py
@@ -598,3 +598,97 @@ class TestFileManagerIntegration:
         for file_path in files_created:
             manager.delete_file(file_path)
             assert not Path(file_path).exists()
+
+
+class TestCleanupOldFiles:
+    """Test age-based cleanup of the output directory."""
+
+    @staticmethod
+    def _age_file(path: Path, hours: float) -> None:
+        """Backdate a file's mtime by the given number of hours."""
+        old_time = path.stat().st_mtime - hours * 3600
+        os.utime(str(path), (old_time, old_time))
+
+    def test_removes_files_older_than_max_age(self, temp_dir):
+        """Should delete old files and spare recent ones."""
+        manager = FileManager(str(temp_dir / "uploads"), str(temp_dir / "outputs"))
+        old_file = Path(manager.output_folder) / "old.wav"
+        old_file.write_bytes(b"x" * 10)
+        self._age_file(old_file, hours=2)
+        new_file = Path(manager.output_folder) / "new.wav"
+        new_file.write_bytes(b"y" * 20)
+
+        result = manager.cleanup_old_files(max_age_hours=1.0)
+
+        assert result.is_success
+        assert result.value is not None
+        assert result.value.files_removed == 1
+        assert result.value.bytes_freed == 10
+        assert result.value.errors == ()
+        assert not old_file.exists()
+        assert new_file.exists()
+
+    def test_ignores_subdirectories(self, temp_dir):
+        """Should never touch directories inside the output folder."""
+        manager = FileManager(str(temp_dir / "uploads"), str(temp_dir / "outputs"))
+        subdir = Path(manager.output_folder) / "nested"
+        subdir.mkdir()
+        self._age_file(subdir, hours=48)
+
+        result = manager.cleanup_old_files(max_age_hours=1.0)
+
+        assert result.is_success
+        assert result.value is not None
+        assert result.value.files_removed == 0
+        assert subdir.exists()
+
+    def test_leaves_upload_folder_untouched(self, temp_dir):
+        """Should only clean the output folder."""
+        manager = FileManager(str(temp_dir / "uploads"), str(temp_dir / "outputs"))
+        upload = Path(manager.upload_folder) / "doc.pdf"
+        upload.write_bytes(b"pdf")
+        self._age_file(upload, hours=48)
+
+        result = manager.cleanup_old_files(max_age_hours=1.0)
+
+        assert result.is_success
+        assert upload.exists()
+
+    @pytest.mark.parametrize("bad_age", [0.0, -1.0, -24.0, float("nan"), float("inf")])
+    def test_rejects_non_positive_or_non_finite_age(self, temp_dir, bad_age):
+        """A negative age would put the cutoff in the future and delete everything."""
+        manager = FileManager(str(temp_dir / "uploads"), str(temp_dir / "outputs"))
+        victim = Path(manager.output_folder) / "current.wav"
+        victim.write_bytes(b"audio")
+
+        result = manager.cleanup_old_files(max_age_hours=bad_age)
+
+        assert result.is_failure
+        assert victim.exists()
+
+    def test_records_error_and_continues_on_delete_failure(self, temp_dir):
+        """A file that fails to delete should be reported, not abort the pass."""
+        manager = FileManager(str(temp_dir / "uploads"), str(temp_dir / "outputs"))
+        stubborn = Path(manager.output_folder) / "stubborn.wav"
+        stubborn.write_bytes(b"x")
+        self._age_file(stubborn, hours=2)
+        removable = Path(manager.output_folder) / "removable.wav"
+        removable.write_bytes(b"y")
+        self._age_file(removable, hours=2)
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self: Path, *args: object, **kwargs: object) -> None:
+            if self.name == "stubborn.wav":
+                raise OSError("permission denied")
+            original_unlink(self, *args, **kwargs)  # type: ignore[arg-type]
+
+        with patch.object(Path, "unlink", failing_unlink):
+            result = manager.cleanup_old_files(max_age_hours=1.0)
+
+        assert result.is_success
+        assert result.value is not None
+        assert result.value.files_removed == 1
+        assert len(result.value.errors) == 1
+        assert "stubborn.wav" in result.value.errors[0]
+        assert not removable.exists()

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -5,9 +5,12 @@ using real Flask test client with dependency injection.
 """
 
 from collections.abc import Generator
+from contextlib import contextmanager
+import dataclasses
 from io import BytesIO
 import json
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 from flask import Flask
@@ -15,7 +18,7 @@ from flask.testing import FlaskClient
 import pytest
 
 from app_factory import create_app
-from application.config.app_configs import FlaskConfig
+from application.config.app_configs import AdminConfig, FlaskConfig
 from application.config.file_configs import FileCleanupConfig, FileConfig
 from application.config.processing_configs import LLMConfig, OCRConfig, PerformanceConfig, TextProcessingConfig
 from application.config.system_config import SystemConfig
@@ -554,3 +557,100 @@ class TestBackgroundCompletionHandler:
         progress = store.get("op-cancelled")
         assert progress is not None
         assert progress.is_error is False
+
+
+@contextmanager
+def _app_with_admin(base_config: SystemConfig, admin: AdminConfig) -> Generator[FlaskClient, None, None]:
+    """Build a test client whose config has the given admin gating settings."""
+    config = dataclasses.replace(base_config, admin=admin)
+    with (
+        patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", True),
+        patch("application.config.system_config.SystemConfig.from_yaml") as mock_config,
+    ):
+        mock_config.return_value = config
+        app = create_app()
+        app.config.update(
+            {
+                "TESTING": True,
+                "UPLOAD_FOLDER": config.files.upload_folder,
+                "AUDIO_FOLDER": config.files.audio_folder,
+            }
+        )
+        register_routes(app)
+        yield app.test_client()
+
+
+class TestAdminEndpointGating:
+    """Admin endpoints must be opt-in and honor the configured token."""
+
+    ADMIN_REQUESTS: ClassVar[list[tuple[str, str]]] = [
+        ("GET", "/admin/file_stats"),
+        ("GET", "/admin/test"),
+        ("POST", "/admin/cleanup"),
+        ("POST", "/admin/cleanup_scheduler"),
+    ]
+
+    def test_admin_disabled_by_default_returns_404(self, client: FlaskClient) -> None:
+        """With the default config every /admin endpoint should look nonexistent."""
+        for method, path in self.ADMIN_REQUESTS:
+            response = client.open(path, method=method)
+            assert response.status_code == 404, f"{method} {path} should 404 when admin is disabled"
+
+    def test_admin_enabled_without_token_allows_access(self, flask_test_config: SystemConfig) -> None:
+        """Enabling admin without a token opens the endpoints (localhost use case)."""
+        with _app_with_admin(flask_test_config, AdminConfig(enabled=True)) as admin_client:
+            response = admin_client.get("/admin/test")
+            assert response.status_code == 200
+
+    def test_admin_token_rejects_missing_or_wrong_header(self, flask_test_config: SystemConfig) -> None:
+        """With a token configured, requests without the right header get 403."""
+        with _app_with_admin(flask_test_config, AdminConfig(enabled=True, token="hunter2")) as admin_client:  # noqa: S106
+            assert admin_client.get("/admin/test").status_code == 403
+            wrong = admin_client.get("/admin/test", headers={"X-Admin-Token": "wrong"})
+            assert wrong.status_code == 403
+
+    def test_admin_token_accepts_correct_header(self, flask_test_config: SystemConfig) -> None:
+        """The configured token in X-Admin-Token unlocks the endpoints."""
+        with _app_with_admin(flask_test_config, AdminConfig(enabled=True, token="hunter2")) as admin_client:  # noqa: S106
+            response = admin_client.get("/admin/test", headers={"X-Admin-Token": "hunter2"})
+            assert response.status_code == 200
+
+
+class TestAdminCleanupEndpoint:
+    """Validation and delegation behavior of POST /admin/cleanup."""
+
+    @pytest.mark.parametrize("bad_age", ["-5", "0", "nan", "inf", "-inf", "not-a-number"])
+    def test_rejects_invalid_max_age_hours(self, flask_test_config: SystemConfig, bad_age: str) -> None:
+        """Invalid ages must 400 before any file is touched."""
+        audio_dir = Path(flask_test_config.files.audio_folder)
+        victim = audio_dir / "current.wav"
+        victim.write_bytes(b"audio")
+
+        with _app_with_admin(flask_test_config, AdminConfig(enabled=True)) as admin_client:
+            response = admin_client.post("/admin/cleanup", data={"max_age_hours": bad_age})
+
+        assert response.status_code == 400
+        assert victim.exists()
+
+    def test_removes_only_files_older_than_cutoff(self, flask_test_config: SystemConfig) -> None:
+        """A valid request should delete old files and report stats."""
+        import os as os_module
+        import time as time_module
+
+        audio_dir = Path(flask_test_config.files.audio_folder)
+        old_file = audio_dir / "old.wav"
+        old_file.write_bytes(b"x" * 10)
+        old_time = time_module.time() - 2 * 3600
+        os_module.utime(old_file, (old_time, old_time))
+        new_file = audio_dir / "new.wav"
+        new_file.write_bytes(b"y")
+
+        with _app_with_admin(flask_test_config, AdminConfig(enabled=True)) as admin_client:
+            response = admin_client.post("/admin/cleanup", data={"max_age_hours": "1"})
+
+        assert response.status_code == 200
+        payload = response.get_json()
+        assert payload["files_removed"] == 1
+        assert payload["max_age_hours"] == 1.0
+        assert not old_file.exists()
+        assert new_file.exists()

--- a/tests/unit/test_system_config_yaml.py
+++ b/tests/unit/test_system_config_yaml.py
@@ -100,6 +100,26 @@ class TestSystemConfigYAMLLoading:
         with pytest.raises(ValueError, match="<= 8"):
             SystemConfig.from_yaml(config_file)
 
+    def test_from_yaml_admin_disabled_by_default(self, tmp_path: Path):
+        """Admin endpoints should be opt-in."""
+        config_file = _write_yaml_config(tmp_path, {"tts": {"engine": "piper"}})
+        config = SystemConfig.from_yaml(config_file)
+        assert config.admin.enabled is False
+        assert config.admin.token is None
+
+    def test_from_yaml_admin_enabled_with_token(self, tmp_path: Path):
+        """Should parse admin.enabled and the token from the secrets section."""
+        config_data = {
+            "tts": {"engine": "piper"},
+            "admin": {"enabled": True},
+            "secrets": {"admin_token": "s3cret-token"},
+        }
+
+        config_file = _write_yaml_config(tmp_path, config_data)
+        config = SystemConfig.from_yaml(config_file)
+        assert config.admin.enabled is True
+        assert config.admin.token == "s3cret-token"  # noqa: S105
+
     def test_from_yaml_missing_file_raises_error(self):
         """Test that missing YAML file raises appropriate error."""
         with pytest.raises(FileNotFoundError) as exc_info:


### PR DESCRIPTION
## Summary

Fixes #35 and #40 together, since `/admin/cleanup` sits at the intersection of both.

### Admin endpoint gating (#35)
- New `admin.enabled` config flag, **default off** — all `/admin/*` endpoints return 404 when disabled, hiding their existence.
- Optional `secrets.admin_token`: when set, requests must send it as the `X-Admin-Token` header (checked with `hmac.compare_digest`); wrong/missing token → 403.
- `max_age_hours` on `POST /admin/cleanup` is now validated before any deletion: non-numeric, non-positive, and non-finite values are rejected with 400. Previously a negative value put the cutoff in the future and **deleted the entire audio directory**.

### Cleanup dedupe (#40)
- Single age-based cleanup implementation: `FileManager.cleanup_old_files(max_age_hours)` behind `IFileManager`, returning `Result[CleanupStats]` (new frozen dataclass in `domain/models.py`). It also guards against bad ages itself (defense in depth).
- The `/admin/cleanup` route delegates to it instead of inlining its own mtime-scan loop.
- `FileCleanupScheduler.run_manual_cleanup()` now exists — `/admin/cleanup_scheduler` previously guarded on `hasattr(scheduler, "run_manual_cleanup")`, which never existed, so the endpoint was dead code that always 404'd. It now runs one cleanup pass and reports the deletion count.

## Testing
- 24 new tests (479 total, all passing): FileManager cleanup semantics (age cutoff, subdirs skipped, upload folder untouched, invalid ages rejected, per-file error handling), scheduler manual cleanup, admin gating end-to-end (404 when disabled, 403 on bad token, 200 with correct token), `/admin/cleanup` input validation and old/new file selection, and YAML parsing of the new config keys.
- `ruff check`, `ruff format --check`, strict `mypy` all clean.

Closes #35
Closes #40