### PR TITLE
fix: minor input-validation and metadata cleanups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,9 @@ packages = ["application", "domain", "infrastructure"]
 
 [project]
 name = "pdf2wav"
-version = "1.0.0"
+version = "0.1.0"
 description = "Convert PDF documents to audio files with TTS engines"
-authors = [{name = "PDF2WAV Team"}]
+authors = [{name = "Nicolai Hansen", email = "nbhansen@gmail.com"}]
 license = "MIT"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -241,6 +241,7 @@ omit = [
     "*/test_*.py",
     "uploads/*",
     "audio_outputs/*",
+    "app.py",  # dev-server entry script, not exercised by tests
 ]
 
 [tool.coverage.report]

--- a/routes.py
+++ b/routes.py
@@ -32,6 +32,7 @@ from domain.interfaces import IFileManager
 from domain.models import PageRange, TimedAudioResult
 from utils import (
     allowed_file,
+    parse_page_range_from_form,
 )
 
 
@@ -305,9 +306,10 @@ def register_routes(app: Flask) -> None:
             return jsonify({"error": f"Invalid file '{filename}'. Only PDF files are supported for processing."}), 400
 
         try:
-            # Save temporary file
-            original_filename = secure_filename(file.filename)
-            temp_path = Path(app.config["UPLOAD_FOLDER"]) / f"temp_{original_filename}"
+            # Save temporary file; UUID prefix avoids collisions between
+            # concurrent requests uploading identically-named files
+            original_filename = secure_filename(file.filename) or "upload.pdf"
+            temp_path = Path(app.config["UPLOAD_FOLDER"]) / f"temp_{uuid.uuid4().hex}_{original_filename}"
             file.save(str(temp_path))
 
             # Use document engine to get PDF info
@@ -368,6 +370,13 @@ def register_routes(app: Flask) -> None:
         if error or file is None:
             return error or "No file provided"
 
+        # Reject bad page ranges before the file is saved and queued; the same
+        # parse in the background thread would surface as a generic failure.
+        try:
+            parse_page_range_from_form(request.form)
+        except ValueError as e:
+            return f"Invalid page range: {e}", 400
+
         route_logger = get_logger("routes")
 
         # Generate unique operation ID
@@ -383,7 +392,8 @@ def register_routes(app: Flask) -> None:
         config = get_app_config()
         if not file.filename:
             return "No filename provided", 400
-        original_filename = secure_filename(file.filename)
+        # secure_filename can strip a hostile name down to nothing
+        original_filename = secure_filename(file.filename) or "upload.pdf"
         saved_path = Path(config.files.upload_folder) / f"{operation_id}_{original_filename}"
         file.save(str(saved_path))
         route_logger.info("Upload received: %s (timing=%s, op=%s)", original_filename, enable_timing, operation_id[:8])

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -654,3 +654,35 @@ class TestAdminCleanupEndpoint:
         assert payload["max_age_hours"] == 1.0
         assert not old_file.exists()
         assert new_file.exists()
+
+
+class TestUploadPageRangeValidation:
+    """Bad page ranges must be rejected at upload time, not in the background."""
+
+    @pytest.mark.parametrize(
+        ("start", "end", "expected_fragment"),
+        [
+            ("abc", "5", "whole number"),
+            ("0", "5", "1 or greater"),
+            ("7", "3", "cannot be after"),
+        ],
+    )
+    def test_invalid_page_range_returns_400(
+        self, client: FlaskClient, start: str, end: str, expected_fragment: str
+    ) -> None:
+        """The upload should fail fast with a clear validation message."""
+        response = client.post(
+            "/upload",
+            data={
+                "pdf_file": (BytesIO(b"%PDF-1.4 fake"), "doc.pdf"),
+                "use_page_range": "on",
+                "start_page": start,
+                "end_page": end,
+            },
+            content_type="multipart/form-data",
+        )
+
+        assert response.status_code == 400
+        body = response.get_data(as_text=True)
+        assert "Invalid page range" in body
+        assert expected_fragment in body

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,60 @@
+# tests/unit/test_utils.py
+"""Tests for form-parsing utilities."""
+
+import pytest
+
+from domain.models import PageRange
+from utils import allowed_file, parse_page_range_from_form
+
+
+class TestAllowedFile:
+    """Test upload extension filtering."""
+
+    @pytest.mark.parametrize("filename", ["paper.pdf", "PAPER.PDF", "a.b.pdf"])
+    def test_accepts_pdf(self, filename: str):
+        """Should accept .pdf in any case."""
+        assert allowed_file(filename) is True
+
+    @pytest.mark.parametrize("filename", ["paper.txt", "paper", "pdf", ".pdf.exe"])
+    def test_rejects_non_pdf(self, filename: str):
+        """Should reject anything that is not a .pdf."""
+        assert allowed_file(filename) is False
+
+
+class TestParsePageRangeFromForm:
+    """Test page range parsing and validation."""
+
+    def test_unchecked_box_returns_full_document(self):
+        """Fields are ignored when use_page_range is off."""
+        form = {"start_page": "garbage", "end_page": "-3"}
+        assert parse_page_range_from_form(form) == PageRange()
+
+    def test_parses_valid_range(self):
+        """Should parse both bounds as integers."""
+        form = {"use_page_range": "on", "start_page": "2", "end_page": "5"}
+        assert parse_page_range_from_form(form) == PageRange(start_page=2, end_page=5)
+
+    def test_parses_open_ended_range(self):
+        """A missing bound stays None."""
+        form = {"use_page_range": "on", "start_page": "3", "end_page": ""}
+        assert parse_page_range_from_form(form) == PageRange(start_page=3, end_page=None)
+
+    @pytest.mark.parametrize("bad_value", ["abc", "1.5", "2; DROP TABLE", " "])
+    def test_rejects_non_numeric_input(self, bad_value: str):
+        """Garbage input should raise a clear ValueError, not a bare int() crash."""
+        form = {"use_page_range": "on", "start_page": bad_value.strip() or "abc", "end_page": "5"}
+        with pytest.raises(ValueError, match="whole number"):
+            parse_page_range_from_form(form)
+
+    @pytest.mark.parametrize("bad_value", ["0", "-1", "-99"])
+    def test_rejects_non_positive_pages(self, bad_value: str):
+        """Pages are 1-based; zero and negatives are invalid."""
+        form = {"use_page_range": "on", "start_page": bad_value, "end_page": ""}
+        with pytest.raises(ValueError, match="1 or greater"):
+            parse_page_range_from_form(form)
+
+    def test_rejects_inverted_range(self):
+        """A start page after the end page would silently extract nothing downstream."""
+        form = {"use_page_range": "on", "start_page": "7", "end_page": "3"}
+        with pytest.raises(ValueError, match="cannot be after"):
+            parse_page_range_from_form(form)

--- a/utils.py
+++ b/utils.py
@@ -12,8 +12,24 @@ def allowed_file(filename: str) -> bool:
     return "." in filename and filename.rsplit(".", 1)[1].lower() in {"pdf"}
 
 
+def _parse_page_number(raw: str, label: str) -> int:
+    """Parse a 1-based page number from form input."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise ValueError(f"{label} must be a whole number, got '{raw}'") from None
+    if value < 1:
+        raise ValueError(f"{label} must be 1 or greater, got {value}")
+    return value
+
+
 def parse_page_range_from_form(form: FormData) -> PageRange:
-    """Parse page range from Flask form data."""
+    """Parse page range from Flask form data.
+
+    Raises:
+        ValueError: if a page field is not a positive integer, or the start
+            page comes after the end page.
+    """
     use_page_range = form.get("use_page_range") == "on"
 
     if not use_page_range:
@@ -26,10 +42,13 @@ def parse_page_range_from_form(form: FormData) -> PageRange:
     end_page_str = str(form.get("end_page", "")).strip()
 
     if start_page_str:
-        start_page = int(start_page_str)
+        start_page = _parse_page_number(start_page_str, "start page")
 
     if end_page_str:
-        end_page = int(end_page_str)
+        end_page = _parse_page_number(end_page_str, "end page")
+
+    if start_page is not None and end_page is not None and start_page > end_page:
+        raise ValueError(f"start page ({start_page}) cannot be after end page ({end_page})")
 
     return PageRange(start_page=start_page, end_page=end_page)
 

--- a/uv.lock
+++ b/uv.lock
@@ -900,7 +900,7 @@ wheels = [
 
 [[package]]
 name = "pdf2wav"
-version = "1.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

Fixes #46, all four items:

1. **Page range validation** — `parse_page_range_from_form` no longer calls `int()` on raw form input. Non-numeric values, zero/negative pages, and inverted ranges (start > end) now raise `ValueError` with a specific message. `_handle_upload` validates the range **before** saving the file or queueing background work and returns 400 with the message — previously garbage like `start_page=abc` crashed in the background thread and surfaced as a generic processing failure. The inverted-range check also closes the earlier review finding that a start > end range silently extracts zero pages.
2. **`/get_pdf_info` temp file collision** — temp files now get a `uuid4().hex` prefix, so concurrent requests uploading identically-named PDFs can't clobber each other. Empty `secure_filename()` results (hostile filenames stripped to nothing) fall back to `upload.pdf`, both here and in `_handle_upload`.
3. **pyproject metadata** — placeholder `1.0.0` / "PDF2WAV Team" replaced with `0.1.0` and the real author.
4. **Coverage config** — `app.py` (dev-server entry script) is now omitted; `routes.py`/`app_factory.py`/`utils.py` stay measured since they're real code exercised by tests.

## Testing
- New `tests/unit/test_utils.py` (18 tests): extension filtering, valid/open-ended ranges, non-numeric/non-positive/inverted rejection, fields ignored when the checkbox is off.
- New e2e tests: uploads with bad ranges return 400 with the specific validation message.
- 500 tests total, all passing; ruff + format + strict mypy clean.

Closes #46