### PR TITLE
docs: update repo name references after rename to VerbatimPapers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ Please be respectful and considerate of others when contributing to this project
 1. Clone the repository:
    ```bash
    git clone <repository-url>
-   cd silly_PDF2WAV
+   cd VerbatimPapers
    ```
 
 2. Install system dependencies:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ sudo pacman -S tesseract ffmpeg espeak-ng python
 
 ```bash
 git clone <repository-url>
-cd silly_PDF2WAV
+cd VerbatimPapers
 
 # Install uv (if not already installed)
 curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -112,7 +112,7 @@ When running in a container, override config using environment variables prefixe
 ## Project Structure
 
 ```
-silly_PDF2WAV/
+VerbatimPapers/
 ├── app.py                 # Flask entry point
 ├── app_factory.py         # Application factory with DI
 ├── routes.py              # Flask route handlers


### PR DESCRIPTION
## Summary

The repo has been renamed `silly_PDF2WAV` → `VerbatimPapers` (GitHub redirects the old URLs). This updates the three remaining references: the `cd` step in README and CONTRIBUTING, and the project-structure diagram root.

App-level branding (the `pdf2wav` package name, `PDF2WAV_*` env var prefix, ASCII art) is untouched — say the word if you want that renamed too.

Closes #50