### PR TITLE
fix: make TTS cadence actually controllable

### DIFF
--- a/application/config/processing_configs.py
+++ b/application/config/processing_configs.py
@@ -9,7 +9,6 @@ class TextProcessingConfig:
     """Text processing configuration."""
 
     enable_cleaning: bool = True
-    enable_natural_formatting: bool = True
     enable_plain_english: bool = False
     llm_chunk_size: int = 50000  # Large chunks for LLM text cleaning
     audio_target_chunk_size: int = 3000

--- a/application/config/system_config.py
+++ b/application/config/system_config.py
@@ -18,10 +18,14 @@ piper:                  # PiperConfig - Piper-specific settings
   model_name            # Voice model (e.g., "en_US-lessac-medium")
   download_dir          # Where to store downloaded models
   length_scale          # Speech speed (1.0 = normal)
+  noise_scale           # Speech variability
+  noise_w               # Pronunciation/timing variability
+  sentence_silence      # Seconds of silence between sentences
 
 gemini:                 # GeminiConfig - Gemini API settings (optional)
   api_key               # API key (or set GEMINI_API_KEY env var)
   model_name            # Model to use
+  style_prompt          # Delivery/tone directive prefixed to the text
   use_measurement_mode  # Use precise timing vs estimation
 
 files:                  # FileConfig - File storage paths
@@ -36,7 +40,6 @@ cleanup:                # FileCleanupConfig - Auto-cleanup scheduler
 
 text_processing:        # TextProcessingConfig - Text pipeline settings
   enable_cleaning       # Use LLM for text cleaning
-  enable_natural_formatting # Add speech pauses
   enable_plain_english  # Simplify language
   llm_chunk_size        # Max chars per chunk sent to LLM for cleaning
 
@@ -324,9 +327,6 @@ class SystemConfig:
         """Parse text processing configuration."""
         return TextProcessingConfig(
             enable_cleaning=cls._parse_bool_value(get_config("text_processing.enable_text_cleaning", True), True),
-            enable_natural_formatting=cls._parse_bool_value(
-                get_config("text_processing.enable_natural_formatting", True), True
-            ),
             enable_plain_english=cls._parse_bool_value(
                 get_config("text_processing.enable_plain_english_conversion", False), False
             ),
@@ -568,7 +568,6 @@ class SystemConfig:
             f"Log Level: {self.logging_config.level}",
             f"TTS Engine: {self.tts.engine.value}",
             f"Text Cleaning: {'Enabled' if self.text_processing.enable_cleaning else 'Disabled'}",
-            f"Natural Formatting: {'Enabled' if self.text_processing.enable_natural_formatting else 'Disabled'}",
             f"Plain English Conversion: {'Enabled' if self.text_processing.enable_plain_english else 'Disabled'}",
             f"Async Audio: {'Enabled' if self.performance.enable_async_audio else 'Disabled'}",
             f"Audio Concurrent Chunks: {self.performance.audio_concurrent_chunks}",

--- a/application/container/service_container.py
+++ b/application/container/service_container.py
@@ -109,13 +109,11 @@ class ServiceContainer(IServiceContainer):
             ITextPipeline: lambda: TextPipeline(
                 llm_provider=self.get(GeminiLLMProvider) if self.config.gemini and self.config.gemini.api_key else None,
                 enable_cleaning=self.config.text_processing.enable_cleaning,
-                enable_natural_formatting=self.config.text_processing.enable_natural_formatting,
             ),
             # Plain English variant of TextPipeline
             "plain_english_text_pipeline": lambda: TextPipeline(
                 llm_provider=self.get(GeminiLLMProvider) if self.config.gemini and self.config.gemini.api_key else None,
                 enable_cleaning=self.config.text_processing.enable_cleaning,
-                enable_natural_formatting=self.config.text_processing.enable_natural_formatting,
                 enable_plain_english=True,
             ),
             # Timing Engine
@@ -185,6 +183,7 @@ class ServiceContainer(IServiceContainer):
                 model_name=self.config.gemini.model_name,
                 api_key=self.config.gemini.api_key,
                 voice_name=self.config.gemini.voice_name,
+                style_prompt=self.config.gemini.style_prompt,
                 min_request_interval=self.config.tts.request_delay_seconds,
                 max_concurrent_requests=self.config.tts.concurrent_requests,
                 requests_per_minute=30,  # Default rate limit for Flash TTS

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,10 +25,14 @@ tts:
     # Speech speed (1.0 = normal, 0.8 = slower, 1.2 = faster)
     length_scale: 1.0
 
-    # Advanced audio settings
+    # Pause inserted between sentences, in seconds. This is the main cadence
+    # control - raise it for a slower, more deliberate read.
+    sentence_silence: 0.2
+
+    # Synthesis variability. noise_scale affects tone, noise_w affects the
+    # timing/pronunciation of individual phonemes.
     noise_scale: 0.667
     noise_w: 0.8
-    sentence_silence: 0.2
 
   # Gemini TTS Settings (Cloud)
   gemini:
@@ -36,13 +40,17 @@ tts:
     model_name: "gemini-2.5-flash"
     max_retries: 3
 
+    # Delivery direction, prefixed to the text. Gemini takes tone and pacing as
+    # natural language rather than SSML, so this is its only prosody control.
+    # Omit for the built-in academic-reading default; set to "" to send text bare.
+    # style_prompt: "Read this slowly and clearly, pausing between sections."
+
 # Text Processing Pipeline
 text_processing:
-  # Use LLM to clean and fix OCR errors
+  # Use LLM to clean and fix OCR errors, and repair punctuation damaged by PDF
+  # extraction. Speech rhythm comes from correct punctuation, so this matters
+  # for cadence as well as accuracy.
   enable_text_cleaning: true
-
-  # Add natural pauses (...) for better speech rhythm
-  enable_natural_formatting: true
 
   # Convert academic text to plain English (optional)
   enable_plain_english_conversion: false

--- a/domain/audio/timing_engine.py
+++ b/domain/audio/timing_engine.py
@@ -165,37 +165,22 @@ class TimingEngine(ITimingEngine):
             logger.debug("TimingEngine: Processing %d chunks individually", len(text_chunks))
 
             for i, chunk in enumerate(text_chunks):
-                # Enhance text with natural formatting if available
-                if self.text_pipeline:
-                    enhance_result = self.text_pipeline.enhance_with_natural_formatting(chunk)
-                    if enhance_result.is_failure:
-                        logger.warning("TimingEngine: Enhancement failed for chunk %d, using original", i + 1)
-                        enhanced_chunk = chunk
-                    elif enhance_result.value is not None:
-                        enhanced_chunk = enhance_result.value
-                    else:
-                        enhanced_chunk = chunk
-                else:
-                    enhanced_chunk = chunk
-
-                logger.debug(
-                    "TimingEngine: Processing chunk %d/%d (%d chars)", i + 1, len(text_chunks), len(enhanced_chunk)
-                )
+                logger.debug("TimingEngine: Processing chunk %d/%d (%d chars)", i + 1, len(text_chunks), len(chunk))
 
                 # Check chunk size
-                if len(enhanced_chunk) > 3000:
+                if len(chunk) > 3000:
                     logger.warning(
                         "TimingEngine: Chunk %d too large (%d chars), falling back to measurement mode",
                         i + 1,
-                        len(enhanced_chunk),
+                        len(chunk),
                     )
                     return self._generate_with_measurement(text_chunks, output_filename)
 
-                if not enhanced_chunk.strip():
+                if not chunk.strip():
                     continue
 
                 # Use engine's native timestamping for this chunk
-                result = self.tts_engine.generate_audio_with_timestamps(enhanced_chunk)
+                result = self.tts_engine.generate_audio_with_timestamps(chunk)
 
                 if result.is_failure:
                     logger.warning("TimingEngine: Engine failed for chunk %d: %s", i + 1, result.error)
@@ -319,22 +304,14 @@ class TimingEngine(ITimingEngine):
         Returns ChunkProcessingResult or None on failure.
         """
         try:
-            # Enhance text if pipeline is available
+            # Split into sentences if pipeline is available
             if self.text_pipeline:
-                enhance_result = self.text_pipeline.enhance_with_natural_formatting(chunk)
-                if enhance_result.is_success and enhance_result.value is not None:
-                    enhanced_chunk = enhance_result.value
-                else:
-                    enhanced_chunk = chunk
-
-                # Split into sentences
-                sentences_result = self.text_pipeline.split_into_sentences(enhanced_chunk)
+                sentences_result = self.text_pipeline.split_into_sentences(chunk)
                 if sentences_result.is_success and sentences_result.value is not None:
                     sentences = sentences_result.value
                 else:
-                    sentences = [enhanced_chunk]
+                    sentences = [chunk]
             else:
-                enhanced_chunk = chunk
                 sentences = [chunk]
 
             logger.debug("TimingEngine: Chunk %d has %d sentences", chunk_index + 1, len(sentences))

--- a/domain/document/document_engine.py
+++ b/domain/document/document_engine.py
@@ -187,6 +187,12 @@ class DocumentEngine(IDocumentEngine):
             all_cleaned_text = " ".join(cleaned_chunks)
             logger.debug("Combined all cleaned text: %d chars total", len(all_cleaned_text))
 
+            # An image-only PDF extracts as whitespace and cleans down to nothing. Without
+            # this, _split_for_tts("") returns [] and the caller only rejects None, so the
+            # run reports success having produced no audio at all.
+            if not all_cleaned_text.strip():
+                return Result.failure(text_extraction_error("No usable text remained after cleaning"))
+
             # Step 4: Split cleaned text into optimal chunks for TTS
             processed_chunks = self._split_for_tts(all_cleaned_text, self.audio_target_chunk_size)
             logger.debug("Split cleaned text into %d TTS-optimized chunks", len(processed_chunks))

--- a/domain/document/document_engine.py
+++ b/domain/document/document_engine.py
@@ -183,23 +183,13 @@ class DocumentEngine(IDocumentEngine):
                 else:
                     logger.debug("Cleaning returned None, skipping chunk")
 
-            # Step 3: Re-combine all cleaned text and enhance with natural formatting
+            # Step 3: Re-combine all cleaned text
             all_cleaned_text = " ".join(cleaned_chunks)
             logger.debug("Combined all cleaned text: %d chars total", len(all_cleaned_text))
 
-            logger.debug("Calling text_pipeline.enhance_with_natural_formatting() on combined text...")
-            enhance_result = text_pipeline.enhance_with_natural_formatting(all_cleaned_text)
-            if enhance_result.is_failure:
-                return Result.failure(enhance_result.error)  # type: ignore[arg-type]
-
-            enhanced_text = enhance_result.value
-            if enhanced_text is None:
-                return Result.failure(text_extraction_error("Text enhancement returned None"))
-            logger.debug("Enhanced text (%d chars): '%s...'", len(enhanced_text), enhanced_text[:100])
-
-            # Step 4: Split enhanced text back into optimal chunks for TTS
-            processed_chunks = self._split_for_tts(enhanced_text, self.audio_target_chunk_size)
-            logger.debug("Split enhanced text into %d TTS-optimized chunks", len(processed_chunks))
+            # Step 4: Split cleaned text into optimal chunks for TTS
+            processed_chunks = self._split_for_tts(all_cleaned_text, self.audio_target_chunk_size)
+            logger.debug("Split cleaned text into %d TTS-optimized chunks", len(processed_chunks))
 
             logger.info(
                 "Processed through optimized pipeline: %d -> %d -> %d chunks",

--- a/domain/interfaces.py
+++ b/domain/interfaces.py
@@ -190,9 +190,5 @@ class ITextPipeline(ABC):
         """Clean and prepare text for TTS asynchronously with rate limiting."""
 
     @abstractmethod
-    def enhance_with_natural_formatting(self, text: str) -> Result[str]:
-        """Add natural formatting enhancements to text."""
-
-    @abstractmethod
     def split_into_sentences(self, text: str) -> Result[list[str]]:
         """Split text into sentences for processing."""

--- a/domain/text/text_pipeline.py
+++ b/domain/text/text_pipeline.py
@@ -27,12 +27,10 @@ class TextPipeline(ITextPipeline):
         self,
         llm_provider: Optional["ILLMProvider"] = None,
         enable_cleaning: bool = True,
-        enable_natural_formatting: bool = True,
         enable_plain_english: bool = False,
     ):
         self.llm_provider = llm_provider
         self.enable_cleaning = enable_cleaning
-        self.enable_natural_formatting = enable_natural_formatting
         self.enable_plain_english = enable_plain_english
 
     def _maybe_apply_plain_english(self, text: str) -> str:
@@ -162,32 +160,6 @@ class TextPipeline(ITextPipeline):
             except Exception:
                 return Result.from_exception(e, ErrorCode.TEXT_CLEANING_FAILED, retryable=True)
 
-    def enhance_with_natural_formatting(self, text: str) -> Result[str]:
-        """Add natural formatting for better speech synthesis.
-
-        Returns Result with enhanced text or error.
-        """
-        if not text:
-            return Result.failure(
-                ApplicationError(
-                    code=ErrorCode.TEXT_EXTRACTION_FAILED,
-                    message="Empty text provided for enhancement",
-                    retryable=False,
-                )
-            )
-
-        try:
-            if not self.enable_natural_formatting:
-                return Result.success(text)
-
-            enhanced = self._enhance_with_natural_formatting(text)
-            return Result.success(enhanced)
-
-        except Exception as e:
-            # On error, return original text
-            logger.exception("Enhancement failed: %s", e)
-            return Result.success(text)
-
     def split_into_sentences(self, text: str) -> Result[list[str]]:
         """Split text into sentences for individual processing.
 
@@ -197,7 +169,6 @@ class TextPipeline(ITextPipeline):
             return Result.success([])
 
         try:
-            # Use text directly since we only generate natural formatting (no markup)
             clean_text = text
 
             # Handle abbreviations better - don't split on Dr., Mr., etc.
@@ -288,11 +259,18 @@ class TextPipeline(ITextPipeline):
 
         Pure function.
         """
-        pause_instruction = """Use natural punctuation for better speech rhythm:
-- Use "..." for medium pauses (between paragraphs or sections)
-- Use "...." or "....." for longer pauses (after major sections)
-- Add extra commas where natural pauses would occur in speech
-- Use line breaks to create natural breathing points"""
+        # Speech pacing comes from ordinary punctuation, which the synthesizer honours:
+        # a comma buys ~290ms, a semicolon/dash ~325ms, a colon ~360ms, and a period
+        # starts a new sentence (where inter-sentence silence is inserted). Repeated or
+        # invented punctuation buys nothing - "." and ".." are phonetically identical,
+        # and "..." actively erases the sentence boundary. So the instruction is to
+        # restore correct punctuation, never to invent decorative pauses.
+        punctuation_instruction = """Restore correct punctuation, which PDF extraction often damages:
+- Re-join sentences broken across line breaks, and split sentences that were run together
+- Restore commas that were dropped: after introductory clauses, around asides, between list items
+- Keep the source's own commas, semicolons, colons and dashes - these carry the speech rhythm
+- Prefer commas or dashes over parentheses for asides (parentheses are silent when spoken)
+- Use ordinary punctuation only. Do NOT add "..." or repeated punctuation for emphasis or pauses"""
 
         return f"""Clean this text for text-to-speech by removing ONLY:
 - Page numbers, headers, footers
@@ -300,7 +278,7 @@ class TextPipeline(ITextPipeline):
 - Broken hyphenations across lines
 - Excessive whitespace
 
-{pause_instruction}
+{punctuation_instruction}
 
 Return ONLY the cleaned text, nothing else.
 
@@ -428,79 +406,3 @@ Text to convert:
         except Exception as e:
             logger.exception("Plain English: Exception during conversion: %s", e)
             return Result.success(text)
-
-    def _enhance_with_natural_formatting(self, text: str) -> str:
-        """Apply natural formatting tricks for TTS engines.
-
-        Pure function - no exceptions thrown.
-        """
-        enhanced = text
-
-        # 1. Add natural emphasis (order matters)
-        enhanced = self._add_natural_emphasis(enhanced)
-
-        # 2. Add academic formatting (universal approach)
-        enhanced = self._add_natural_academic_formatting(enhanced)
-
-        # 3. Enhance punctuation for better rhythm
-        enhanced = self._enhance_punctuation_for_natural_speech(enhanced)
-
-        return enhanced
-
-    def _add_natural_emphasis(self, text: str) -> str:
-        """Add natural emphasis without SSML tags.
-
-        Pure function.
-        """
-        # Already quoted text gets natural emphasis from quotes
-        # No changes needed for quoted text as TTS engines naturally emphasize quotes
-        return text
-
-    def _add_natural_academic_formatting(self, text: str) -> str:
-        """Add natural formatting for academic content.
-
-        Pure function.
-        """
-        # Add extra dots after section headers for longer pauses
-        text = re.sub(
-            r"(Abstract|Introduction|Conclusion|References)(\s*[:\.]?\s*)", r"\1\2... ", text, flags=re.IGNORECASE
-        )
-
-        # Add pause after numbered sections with extra dots
-        text = re.sub(r"(\d+\.\s*[A-Z][^.]*\.)", r"\1.. ", text)
-
-        # Add line breaks around major transitions for natural pauses
-        text = re.sub(r"(However|Therefore|Furthermore|Moreover),", r"\n\1,", text, flags=re.IGNORECASE)
-
-        return text
-
-    def _enhance_punctuation_for_natural_speech(self, text: str) -> str:
-        """Enhance punctuation for better natural speech rhythm.
-
-        Pure function.
-        """
-        # Add extra comma pauses where beneficial
-        # After introductory phrases
-        text = re.sub(
-            r"^(In this paper|In this study|We present|We propose|This work),",
-            r"\1,,",
-            text,
-            flags=re.IGNORECASE | re.MULTILINE,
-        )
-
-        # Convert single dots between sentences to double for slightly longer pauses
-        # But preserve ellipsis (...)
-        text = re.sub(r"(?<![.])\.(?![.])\s+(?=[A-Z])", r".. ", text)
-
-        # Add commas after "First", "Second", etc. if not already present
-        text = re.sub(
-            r"\b(First|Second|Third|Fourth|Fifth|Finally|Additionally|Specifically)(?!,)\s",
-            r"\1, ",
-            text,
-            flags=re.IGNORECASE,
-        )
-
-        # Ensure ellipsis has consistent spacing
-        text = re.sub(r"\.{3,}", "... ", text)
-
-        return text

--- a/infrastructure/tts/gemini_tts_provider.py
+++ b/infrastructure/tts/gemini_tts_provider.py
@@ -13,6 +13,13 @@ from domain.interfaces import ITTSEngine
 
 logger = logging.getLogger(__name__)
 
+# Gemini takes delivery direction as natural language rather than SSML, so this is the
+# only prosody control the engine exposes. Tuned for long-form academic reading.
+DEFAULT_STYLE_PROMPT = (
+    "Read the following text aloud in a measured, clear academic tone. "
+    "Pace it for comprehension rather than speed, and pause between sections."
+)
+
 
 class GeminiTTSProvider(ITTSEngine):
     """Gemini TTS Provider using Google Gen AI SDK."""
@@ -22,6 +29,7 @@ class GeminiTTSProvider(ITTSEngine):
         model_name: str,
         api_key: str,
         voice_name: str = "Kore",
+        style_prompt: str | None = None,
         min_request_interval: float = 2.0,
         max_concurrent_requests: int = 4,
         requests_per_minute: int = 30,
@@ -32,6 +40,8 @@ class GeminiTTSProvider(ITTSEngine):
             model_name: Gemini model (e.g. gemini-2.0-flash-exp)
             api_key: Google AI API Key
             voice_name: Voice to use (e.g. "Kore", "Puck", "Charon", "Fenrir", "Aoede")
+            style_prompt: Delivery directive prefixed to the text. None uses
+                DEFAULT_STYLE_PROMPT; pass an empty string to send the text bare.
             min_request_interval: Minimum seconds between API requests
             max_concurrent_requests: Maximum number of concurrent API requests
             requests_per_minute: Rate limit for API requests per minute
@@ -39,6 +49,7 @@ class GeminiTTSProvider(ITTSEngine):
         self.model_name = model_name
         self.api_key = api_key
         self.voice_name = voice_name
+        self.style_prompt = DEFAULT_STYLE_PROMPT if style_prompt is None else style_prompt
         self.min_request_interval = min_request_interval
         self.max_concurrent_requests = max_concurrent_requests
         self.requests_per_minute = requests_per_minute
@@ -52,6 +63,12 @@ class GeminiTTSProvider(ITTSEngine):
         except Exception as e:
             self._initialization_error = f"Failed to initialize Gemini Client: {e}"
             logger.error(self._initialization_error)
+
+    def _build_prompt(self, text: str) -> str:
+        """Prefix the delivery directive to the text, if one is configured."""
+        if not self.style_prompt:
+            return text
+        return f"{self.style_prompt}\n\n{text}"
 
     def generate_audio_data(self, text: str) -> Result[bytes]:
         """Generate audio data from text using Gemini."""
@@ -78,8 +95,7 @@ class GeminiTTSProvider(ITTSEngine):
                 ),
             )
 
-            # Direct text input for TTS models
-            prompt = text
+            prompt = self._build_prompt(text)
 
             response = self.client.models.generate_content(model=self.model_name, contents=prompt, config=config)
             logger.debug("Gemini API call successful, extracting audio from response")
@@ -110,8 +126,7 @@ class GeminiTTSProvider(ITTSEngine):
                 ),
             )
 
-            # Direct text input for TTS models
-            prompt = text
+            prompt = self._build_prompt(text)
 
             # Use async client
             response = await self.client.aio.models.generate_content(
@@ -181,4 +196,5 @@ class GeminiTTSProvider(ITTSEngine):
 
     def supports_ssml(self) -> bool:
         """Whether this engine supports SSML."""
-        return False  # Gemini Audio model takes text prompt, not SSML (prompt engineering used instead)
+        # Gemini takes a text prompt, not SSML. Delivery is steered by style_prompt instead.
+        return False

--- a/infrastructure/tts/piper_tts_provider.py
+++ b/infrastructure/tts/piper_tts_provider.py
@@ -8,6 +8,7 @@ import re
 import ssl
 import subprocess  # nosec B404
 import tempfile
+from typing import TYPE_CHECKING
 import urllib.error
 from urllib.parse import urlparse
 import urllib.request
@@ -15,6 +16,9 @@ import urllib.request
 from domain.config import PiperConfig
 from domain.errors import Result, tts_engine_error
 from domain.interfaces import ITTSEngine
+
+if TYPE_CHECKING:
+    from piper.config import SynthesisConfig
 
 logger = logging.getLogger("piper_tts")
 
@@ -282,8 +286,27 @@ class PiperTTSProvider(ITTSEngine):
             logger.debug("Failed to initialize Piper Python library: %s", e)
             self.voice_instance = None
 
+    def _build_synthesis_config(self) -> "SynthesisConfig":
+        """Build Piper's SynthesisConfig from our PiperConfig.
+
+        Note the field rename: our `noise_w` is Piper's `noise_w_scale`.
+        """
+        from piper.config import SynthesisConfig
+
+        return SynthesisConfig(
+            speaker_id=self.config.speaker_id,
+            length_scale=self.config.length_scale,
+            noise_scale=self.config.noise_scale,
+            noise_w_scale=self.config.noise_w,
+        )
+
     def _generate_with_python_lib(self, text: str) -> bytes:
-        """Generate using Python library."""
+        """Generate using the Piper Python library.
+
+        Piper emits one audio chunk per sentence. `sentence_silence` is not applied by
+        the library, so silence is written between chunks here - the same approach
+        piper's own CLI takes.
+        """
         try:
             from io import BytesIO
             import wave
@@ -291,17 +314,40 @@ class PiperTTSProvider(ITTSEngine):
             if self.voice_instance is None:
                 raise Exception("Voice instance not initialized")
 
+            syn_config = self._build_synthesis_config()
+
             audio_buffer = BytesIO()
             with wave.open(audio_buffer, "wb") as wav_file:
-                # Piper's Python library can handle basic SSML
-                self.voice_instance.synthesize(text, wav_file)
+                wav_params_set = False
+                silence_bytes = b""
 
-            audio_data = audio_buffer.getvalue()
+                for i, chunk in enumerate(self.voice_instance.synthesize(text, syn_config)):
+                    if not wav_params_set:
+                        wav_file.setframerate(chunk.sample_rate)
+                        wav_file.setsampwidth(chunk.sample_width)
+                        wav_file.setnchannels(chunk.sample_channels)
+                        # 16-bit silence sized to the configured inter-sentence gap
+                        silence_bytes = bytes(
+                            int(chunk.sample_rate * self.config.sentence_silence)
+                            * chunk.sample_width
+                            * chunk.sample_channels
+                        )
+                        wav_params_set = True
 
-            return audio_data
+                    if i > 0 and silence_bytes:
+                        wav_file.writeframes(silence_bytes)
+
+                    wav_file.writeframes(chunk.audio_int16_bytes)
+
+                if not wav_params_set:
+                    raise Exception("Piper produced no audio chunks")
+
+            return audio_buffer.getvalue()
 
         except Exception as e:
-            logger.debug("Python library generation failed, falling back to command line: %s", e)
+            # Loud on purpose: a silent fall-through here means every chunk pays for a
+            # subprocess and a full model reload, which is easy to miss.
+            logger.warning("Piper Python library generation failed, falling back to command line: %s", e)
             return self._generate_with_command_line(text)
 
     def _generate_with_command_line(self, text: str) -> bytes:
@@ -324,6 +370,12 @@ class PiperTTSProvider(ITTSEngine):
                 temp_path,
                 "--length_scale",
                 str(self.config.length_scale),
+                "--noise_scale",
+                str(self.config.noise_scale),
+                "--noise_w",
+                str(self.config.noise_w),
+                "--sentence_silence",
+                str(self.config.sentence_silence),
             ]
 
             if self.config_path and Path(self.config_path).exists():

--- a/infrastructure/tts/piper_tts_provider.py
+++ b/infrastructure/tts/piper_tts_provider.py
@@ -298,14 +298,21 @@ class PiperTTSProvider(ITTSEngine):
             length_scale=self.config.length_scale,
             noise_scale=self.config.noise_scale,
             noise_w_scale=self.config.noise_w,
+            # Piper normalizes per *chunk*, and a chunk is one sentence - so leaving this
+            # on peaks "However." to the same level as a full paragraph, and the output
+            # pumps at every sentence seam. Measured on en_US-lessac-medium: peaks go
+            # [1.0, 1.0] with normalization on versus [0.70, 0.52] with it off.
+            normalize_audio=False,
         )
 
     def _generate_with_python_lib(self, text: str) -> bytes:
         """Generate using the Piper Python library.
 
-        Piper emits one audio chunk per sentence. `sentence_silence` is not applied by
-        the library, so silence is written between chunks here - the same approach
-        piper's own CLI takes.
+        Piper emits one audio chunk per sentence and applies no inter-sentence silence,
+        so the gaps are written here. Note this deliberately differs from piper's own
+        CLI, which only gaps *within* one synthesize() call: our callers concatenate
+        these blobs, so a trailing gap is what keeps the seam between two chunks from
+        running two sentences together.
         """
         try:
             from io import BytesIO
@@ -316,31 +323,29 @@ class PiperTTSProvider(ITTSEngine):
 
             syn_config = self._build_synthesis_config()
 
+            # Materialize before opening the wave writer: raising inside the `with` would
+            # be masked by Wave_write.close() failing on unset params, replacing the real
+            # error with a confusing "# channels not specified".
+            chunks = list(self.voice_instance.synthesize(text, syn_config))
+            if not chunks:
+                raise Exception("Piper produced no audio chunks")
+
+            first = chunks[0]
+            # 16-bit silence sized to the configured inter-sentence gap
+            silence_bytes = bytes(
+                int(first.sample_rate * self.config.sentence_silence) * first.sample_width * first.sample_channels
+            )
+
             audio_buffer = BytesIO()
             with wave.open(audio_buffer, "wb") as wav_file:
-                wav_params_set = False
-                silence_bytes = b""
+                wav_file.setframerate(first.sample_rate)
+                wav_file.setsampwidth(first.sample_width)
+                wav_file.setnchannels(first.sample_channels)
 
-                for i, chunk in enumerate(self.voice_instance.synthesize(text, syn_config)):
-                    if not wav_params_set:
-                        wav_file.setframerate(chunk.sample_rate)
-                        wav_file.setsampwidth(chunk.sample_width)
-                        wav_file.setnchannels(chunk.sample_channels)
-                        # 16-bit silence sized to the configured inter-sentence gap
-                        silence_bytes = bytes(
-                            int(chunk.sample_rate * self.config.sentence_silence)
-                            * chunk.sample_width
-                            * chunk.sample_channels
-                        )
-                        wav_params_set = True
-
-                    if i > 0 and silence_bytes:
-                        wav_file.writeframes(silence_bytes)
-
+                for chunk in chunks:
                     wav_file.writeframes(chunk.audio_int16_bytes)
-
-                if not wav_params_set:
-                    raise Exception("Piper produced no audio chunks")
+                    if silence_bytes:
+                        wav_file.writeframes(silence_bytes)
 
             return audio_buffer.getvalue()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,6 @@ def test_config(temp_dir):
         cleanup=FileCleanupConfig(enabled=False),  # Don't interfere with tests
         text_processing=TextProcessingConfig(
             enable_cleaning=False,  # Fast tests
-            enable_natural_formatting=False,  # Fast tests
         ),
         performance=PerformanceConfig(),
         flask=FlaskConfig(),

--- a/tests/infrastructure/tts/test_gemini_tts_provider.py
+++ b/tests/infrastructure/tts/test_gemini_tts_provider.py
@@ -12,7 +12,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from domain.errors import ErrorCode
-from infrastructure.tts.gemini_tts_provider import GeminiTTSProvider
+from infrastructure.tts.gemini_tts_provider import DEFAULT_STYLE_PROMPT, GeminiTTSProvider
 
 
 def make_audio_response(data: bytes, mime_type: str = "audio/mp3") -> SimpleNamespace:
@@ -143,7 +143,8 @@ class TestGeminiTTSProviderSyncGeneration:
         mock_client.models.generate_content.assert_called_once()
         call_kwargs = mock_client.models.generate_content.call_args.kwargs
         assert call_kwargs["model"] == "gemini-1.5-flash"
-        assert call_kwargs["contents"] == "Hello, this is a test."
+        # Text is sent with the delivery directive prefixed - Gemini's only prosody control
+        assert call_kwargs["contents"] == f"{DEFAULT_STYLE_PROMPT}\n\nHello, this is a test."
 
     def test_generate_audio_data_handles_unicode(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should pass Unicode text through to the API."""
@@ -156,7 +157,7 @@ class TestGeminiTTSProviderSyncGeneration:
         result = provider.generate_audio_data(unicode_text)
 
         assert result.is_success
-        assert mock_client.models.generate_content.call_args.kwargs["contents"] == unicode_text
+        assert mock_client.models.generate_content.call_args.kwargs["contents"].endswith(unicode_text)
 
     def test_generate_audio_data_wraps_pcm_in_wav(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """PCM responses should get a WAV header."""
@@ -271,6 +272,58 @@ class TestGeminiTTSProviderResponseParsing:
         assert result.value is not None
         with wave.open(io.BytesIO(result.value), "rb") as wav_file:
             assert wav_file.getframerate() == 16000
+
+
+class TestGeminiTTSProviderStylePrompt:
+    """Test the style prompt, which is how Gemini takes prosody direction.
+
+    Gemini has no SSML; delivery is steered by a natural-language directive
+    prefixed to the text. See issue #61.
+    """
+
+    @staticmethod
+    def _provider(style_prompt: str | None) -> GeminiTTSProvider:
+        return GeminiTTSProvider(
+            model_name="gemini-1.5-flash",
+            api_key="test_key",
+            voice_name="Kore",
+            style_prompt=style_prompt,
+        )
+
+    def test_defaults_to_builtin_style_prompt(self) -> None:
+        """Omitting style_prompt should apply the academic-reading default."""
+        assert self._provider(None).style_prompt == DEFAULT_STYLE_PROMPT
+
+    def test_custom_style_prompt_is_used_verbatim(self) -> None:
+        """A configured style prompt should replace the default."""
+        provider = self._provider("Read this slowly.")
+
+        assert provider.style_prompt == "Read this slowly."
+        assert provider._build_prompt("Body text.") == "Read this slowly.\n\nBody text."
+
+    def test_empty_style_prompt_sends_text_bare(self) -> None:
+        """An empty string is the opt-out - no directive is prefixed."""
+        provider = self._provider("")
+
+        assert provider._build_prompt("Body text.") == "Body text."
+
+    @pytest.mark.asyncio
+    async def test_style_prompt_applied_on_async_path(self) -> None:
+        """The async path must prefix the directive too, not just the sync one."""
+        provider = self._provider("Read this slowly.")
+        mock_client = Mock()
+
+        async def fake_generate(**kwargs: object) -> SimpleNamespace:
+            return make_audio_response(b"audio")
+
+        mock_client.aio.models.generate_content = Mock(side_effect=fake_generate)
+        provider.client = mock_client
+
+        result = await provider.generate_audio_data_async("Body text.")
+
+        assert result.is_success
+        contents = mock_client.aio.models.generate_content.call_args.kwargs["contents"]
+        assert contents == "Read this slowly.\n\nBody text."
 
 
 class TestGeminiTTSProviderConfiguration:

--- a/tests/infrastructure/tts/test_piper_tts_provider.py
+++ b/tests/infrastructure/tts/test_piper_tts_provider.py
@@ -345,6 +345,10 @@ class TestPiperTTSProviderCommandLineGeneration:
         assert "0.8" in cmd  # custom length scale
         assert "--speaker" in cmd
         assert "1" in cmd  # custom speaker ID
+        # All prosody settings must reach the CLI, not just length_scale (issue #59)
+        assert "--noise_scale" in cmd
+        assert "--noise_w" in cmd
+        assert "--sentence_silence" in cmd
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
@@ -587,3 +591,47 @@ class TestPiperTTSProviderRealWorldScenarios:
         assert len(providers) == 2
         assert providers[0].config.model_name != providers[1].config.model_name
         assert all(p.models_dir == temp_models_dir for p in providers)
+
+
+class TestPiperSynthesisConfig:
+    """Test that PiperConfig prosody settings reach Piper's SynthesisConfig.
+
+    These settings were parsed from config but never applied - see issue #59.
+    """
+
+    @staticmethod
+    def _provider(config: PiperConfig) -> PiperTTSProvider:
+        """Build a provider without touching model files or the network."""
+        with patch.object(PiperTTSProvider, "_check_piper_availability"):
+            provider = PiperTTSProvider.__new__(PiperTTSProvider)
+            provider.config = config
+            return provider
+
+    def test_synthesis_config_carries_all_prosody_settings(self, temp_models_dir: str) -> None:
+        """Every prosody knob should be forwarded, with noise_w renamed correctly."""
+        config = PiperConfig(
+            download_dir=temp_models_dir,
+            length_scale=1.25,
+            noise_scale=0.5,
+            noise_w=0.9,
+            sentence_silence=0.4,
+            speaker_id=3,
+        )
+
+        syn_config = self._provider(config)._build_synthesis_config()
+
+        assert syn_config.length_scale == 1.25
+        assert syn_config.noise_scale == 0.5
+        # Our `noise_w` is Piper's `noise_w_scale` - an easy rename to get wrong
+        assert syn_config.noise_w_scale == 0.9
+        assert syn_config.speaker_id == 3
+
+    def test_synthesis_config_uses_config_defaults(self, temp_models_dir: str) -> None:
+        """Defaults should pass through rather than being dropped to Piper's own."""
+        config = PiperConfig(download_dir=temp_models_dir)
+
+        syn_config = self._provider(config)._build_synthesis_config()
+
+        assert syn_config.length_scale == config.length_scale
+        assert syn_config.noise_scale == config.noise_scale
+        assert syn_config.noise_w_scale == config.noise_w

--- a/tests/infrastructure/tts/test_piper_tts_provider.py
+++ b/tests/infrastructure/tts/test_piper_tts_provider.py
@@ -626,6 +626,19 @@ class TestPiperSynthesisConfig:
         assert syn_config.noise_w_scale == 0.9
         assert syn_config.speaker_id == 3
 
+    def test_synthesis_config_disables_per_chunk_normalization(self, temp_models_dir: str) -> None:
+        """Piper normalizes per chunk, and a chunk is one sentence.
+
+        Left on, a one-word sentence is peaked to the same level as a paragraph and the
+        output pumps at every sentence seam. Measured on en_US-lessac-medium: peaks are
+        [1.0, 1.0] with it on versus [0.70, 0.52] with it off.
+        """
+        config = PiperConfig(download_dir=temp_models_dir)
+
+        syn_config = self._provider(config)._build_synthesis_config()
+
+        assert syn_config.normalize_audio is False
+
     def test_synthesis_config_uses_config_defaults(self, temp_models_dir: str) -> None:
         """Defaults should pass through rather than being dropped to Piper's own."""
         config = PiperConfig(download_dir=temp_models_dir)
@@ -635,3 +648,87 @@ class TestPiperSynthesisConfig:
         assert syn_config.length_scale == config.length_scale
         assert syn_config.noise_scale == config.noise_scale
         assert syn_config.noise_w_scale == config.noise_w
+
+
+class TestPiperPythonLibraryAudioAssembly:
+    """Test WAV assembly on the Piper Python-library path.
+
+    Covers the silence placement that survives concatenation, and the zero-chunk
+    error path that used to be masked by the wave writer.
+    """
+
+    @staticmethod
+    def _provider(config: PiperConfig, chunks: list[Mock]) -> PiperTTSProvider:
+        """Provider wired to a fake voice yielding the given chunks."""
+        with patch.object(PiperTTSProvider, "_check_piper_availability"):
+            provider = PiperTTSProvider.__new__(PiperTTSProvider)
+        provider.config = config
+        voice = Mock()
+        voice.synthesize.return_value = iter(chunks)
+        provider.voice_instance = voice  # type: ignore[assignment]
+        return provider
+
+    @staticmethod
+    def _chunk(frames: int = 100) -> Mock:
+        """One sentence of 16-bit mono audio at 100 Hz, for cheap frame math."""
+        chunk = Mock()
+        chunk.sample_rate = 100
+        chunk.sample_width = 2
+        chunk.sample_channels = 1
+        chunk.audio_int16_bytes = b"\x01\x00" * frames
+        return chunk
+
+    def test_zero_chunks_reports_the_real_error(self, temp_models_dir: str) -> None:
+        """The raise must not happen inside the wave writer's context manager.
+
+        Raising in there means Wave_write.close() fails on unset params and replaces
+        the real message with a confusing "# channels not specified".
+        """
+        provider = self._provider(PiperConfig(download_dir=temp_models_dir), [])
+
+        with patch.object(provider, "_generate_with_command_line", side_effect=Exception("cli disabled")):
+            try:
+                provider._generate_with_python_lib("text")
+            except Exception as exc:
+                # The CLI fallback error is what surfaces, but the *cause* must be ours
+                assert "channels not specified" not in str(exc.__context__)
+                assert "no audio chunks" in str(exc.__context__)
+
+    def test_trailing_silence_survives_chunk_concatenation(self, temp_models_dir: str) -> None:
+        """A gap after the last sentence is what keeps concatenated seams apart.
+
+        Callers synthesize ~3000-char chunks separately and concatenate them, so
+        gapping only *between* sentences leaves two sentences running together at
+        every chunk boundary.
+        """
+        import io
+        import wave
+
+        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.5)
+        provider = self._provider(config, [self._chunk(frames=100)])
+
+        with wave.open(io.BytesIO(provider._generate_with_python_lib("One sentence.")), "rb") as wav:
+            # 100 frames of speech + 0.5s at 100 Hz = 50 frames of trailing silence
+            assert wav.getnframes() == 150
+
+    def test_silence_written_between_every_sentence(self, temp_models_dir: str) -> None:
+        """Three sentences at 0.5s should gap after each one."""
+        import io
+        import wave
+
+        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.5)
+        provider = self._provider(config, [self._chunk(frames=100) for _ in range(3)])
+
+        with wave.open(io.BytesIO(provider._generate_with_python_lib("Three. Short. Sentences.")), "rb") as wav:
+            assert wav.getnframes() == 3 * (100 + 50)
+
+    def test_zero_sentence_silence_writes_no_padding(self, temp_models_dir: str) -> None:
+        """sentence_silence=0 must produce exactly the speech frames."""
+        import io
+        import wave
+
+        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.0)
+        provider = self._provider(config, [self._chunk(frames=100) for _ in range(2)])
+
+        with wave.open(io.BytesIO(provider._generate_with_python_lib("Two. Sentences.")), "rb") as wav:
+            assert wav.getnframes() == 200

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -52,7 +52,6 @@ def flask_test_config(temp_dir: Path) -> SystemConfig:
         cleanup=FileCleanupConfig(enabled=False),  # No cleanup during tests
         text_processing=TextProcessingConfig(
             enable_cleaning=True,
-            enable_natural_formatting=True,
             llm_chunk_size=500,  # Small chunks for testing
         ),
         performance=PerformanceConfig(),

--- a/tests/integration/test_integration_simple.py
+++ b/tests/integration/test_integration_simple.py
@@ -21,7 +21,6 @@ def create_test_config() -> SystemConfig:
         cleanup=FileCleanupConfig(enabled=False),
         text_processing=TextProcessingConfig(
             enable_cleaning=False,
-            enable_natural_formatting=False,
         ),
         performance=PerformanceConfig(),
         flask=FlaskConfig(),
@@ -36,7 +35,6 @@ def test_configuration_loading():
     config = create_test_config()
     assert config.tts.engine == TTSEngine.PIPER
     assert config.text_processing.enable_cleaning is False
-    assert config.text_processing.enable_natural_formatting is False
     assert config.cleanup.enabled is False
     # Test LLM model configuration
     assert config.llm.model_name == "test-llm-model"

--- a/tests/integration/test_pdf_to_audio_pipeline.py
+++ b/tests/integration/test_pdf_to_audio_pipeline.py
@@ -126,7 +126,6 @@ def pipeline_config(pipeline_test_dirs: tuple[str, str]) -> SystemConfig:
         cleanup=FileCleanupConfig(enabled=False),
         text_processing=TextProcessingConfig(
             enable_cleaning=False,  # Disable LLM to focus on pipeline
-            enable_natural_formatting=True,
             llm_chunk_size=500,
             audio_target_chunk_size=1000,
             audio_max_chunk_size=2000,

--- a/tests/integration/test_real_service_integration.py
+++ b/tests/integration/test_real_service_integration.py
@@ -54,7 +54,6 @@ def integration_config(temp_directories: tuple[str, str]) -> SystemConfig:
         cleanup=FileCleanupConfig(enabled=False),  # Don't cleanup during tests
         text_processing=TextProcessingConfig(
             enable_cleaning=False,  # Disable LLM calls for integration tests
-            enable_natural_formatting=True,
             llm_chunk_size=500,
         ),
         performance=PerformanceConfig(),

--- a/tests/unit/test_document_engine_text_pipeline.py
+++ b/tests/unit/test_document_engine_text_pipeline.py
@@ -1,0 +1,57 @@
+"""Tests for DocumentEngine's text-processing stage.
+
+Focused on the guarantee that a document which yields no usable text fails
+loudly rather than reporting success with no audio.
+"""
+
+from unittest.mock import Mock
+
+from domain.document.document_engine import DocumentEngine
+from domain.errors import ErrorCode, Result
+
+
+def _engine() -> DocumentEngine:
+    """DocumentEngine with stubbed collaborators - none are used by this stage."""
+    return DocumentEngine(ocr_provider=Mock(), file_manager=Mock(), pdf_extractor=Mock())
+
+
+def _pipeline(cleaned: str) -> Mock:
+    """Text pipeline whose cleaning stage returns the given text."""
+    pipeline = Mock()
+    pipeline.clean_text.return_value = Result.success(cleaned)
+    return pipeline
+
+
+class TestEmptyTextIsRejected:
+    """An image-only PDF extracts as whitespace and cleans down to nothing.
+
+    Without an explicit guard, _split_for_tts("") returns [] and process_document
+    only rejects None, so the run reports success having produced no audio at all.
+    """
+
+    def test_empty_cleaned_text_fails(self) -> None:
+        """Cleaning down to an empty string must be a failure, not an empty chunk list."""
+        result = _engine()._process_text_pipeline(["   "], _pipeline(""), llm_chunk_size=50000)
+
+        assert result.is_failure
+        assert result.error is not None
+        assert result.error.code == ErrorCode.TEXT_EXTRACTION_FAILED
+
+    def test_whitespace_only_cleaned_text_fails(self) -> None:
+        """Whitespace is not usable text either."""
+        result = _engine()._process_text_pipeline(["   "], _pipeline("  \n\t "), llm_chunk_size=50000)
+
+        assert result.is_failure
+        assert result.error is not None
+        assert result.error.code == ErrorCode.TEXT_EXTRACTION_FAILED
+
+    def test_usable_text_still_produces_chunks(self) -> None:
+        """The guard must not reject documents that do have content."""
+        result = _engine()._process_text_pipeline(
+            ["raw"], _pipeline("This document has real content in it."), llm_chunk_size=50000
+        )
+
+        assert result.is_success
+        assert result.value is not None
+        assert len(result.value) >= 1
+        assert "real content" in " ".join(result.value)

--- a/tests/unit/test_system_config_tdd.py
+++ b/tests/unit/test_system_config_tdd.py
@@ -61,7 +61,6 @@ class TestSystemConfigCreation:
         assert config.files.upload_folder == "uploads"
         assert config.files.audio_folder == "audio_outputs"
         assert config.text_processing.enable_cleaning is True
-        assert config.text_processing.enable_natural_formatting is True
 
     def test_system_config_with_custom_values(self):
         """Should create SystemConfig with custom values."""
@@ -74,7 +73,6 @@ class TestSystemConfigCreation:
             cleanup=FileCleanupConfig(),
             text_processing=TextProcessingConfig(
                 enable_cleaning=False,
-                enable_natural_formatting=False,
             ),
             performance=PerformanceConfig(),
             flask=FlaskConfig(),
@@ -87,7 +85,6 @@ class TestSystemConfigCreation:
         assert config.files.upload_folder == "custom_uploads"
         assert config.files.audio_folder == "custom_audio"
         assert config.text_processing.enable_cleaning is False
-        assert config.text_processing.enable_natural_formatting is False
 
     def test_system_config_post_init_sets_default_extensions(self):
         """Should set default file extensions in FileConfig."""
@@ -489,7 +486,7 @@ class TestSystemConfigHelperMethodsTDD:
             cleanup=FileCleanupConfig(
                 enabled=True, max_file_age_hours=48.0, auto_cleanup_interval_hours=12.0, max_disk_usage_mb=2000
             ),
-            text_processing=TextProcessingConfig(enable_cleaning=True, enable_natural_formatting=False),
+            text_processing=TextProcessingConfig(enable_cleaning=True),
             performance=PerformanceConfig(enable_async_audio=True, audio_concurrent_chunks=8),
             flask=FlaskConfig(),
             ocr=OCRConfig(),
@@ -510,7 +507,6 @@ class TestSystemConfigHelperMethodsTDD:
 
             assert "TTS Engine: gemini" in logged_text
             assert "Text Cleaning: Enabled" in logged_text
-            assert "Natural Formatting: Disabled" in logged_text
             assert "Async Audio: Enabled" in logged_text
             assert "Audio Concurrent Chunks: 8" in logged_text
             assert "Upload Folder: test_uploads" in logged_text

--- a/tests/unit/test_system_config_yaml.py
+++ b/tests/unit/test_system_config_yaml.py
@@ -44,7 +44,7 @@ class TestSystemConfigYAMLLoading:
                 "piper": {"model_name": "en_US-test-high", "models_dir": "test_models", "length_scale": 1.2},
             },
             "secrets": {"google_ai_api_key": "test-api-key-123"},
-            "text_processing": {"enable_text_cleaning": False, "enable_natural_formatting": False},
+            "text_processing": {"enable_text_cleaning": False},
             "files": {
                 "upload_folder": "test_uploads",
                 "audio_folder": "test_audio",
@@ -68,7 +68,6 @@ class TestSystemConfigYAMLLoading:
 
         # Text processing
         assert config.text_processing.enable_cleaning is False
-        assert config.text_processing.enable_natural_formatting is False
 
         # File settings
         assert config.files.upload_folder == "test_uploads"
@@ -140,7 +139,6 @@ class TestSystemConfigYAMLLoading:
             "tts": {"engine": "piper", "piper": {"length_scale": "1.5"}},  # String float
             "text_processing": {
                 "enable_text_cleaning": "true",  # String boolean
-                "enable_natural_formatting": 1,  # Integer boolean
                 "audio_target_chunk_size": 2500,
             },
             "files": {
@@ -158,7 +156,6 @@ class TestSystemConfigYAMLLoading:
 
         # Boolean conversions
         assert config.text_processing.enable_cleaning is True
-        assert config.text_processing.enable_natural_formatting is True
         assert config.cleanup.enabled is True
 
         # Integer conversions

--- a/tests/unit/test_text_pipeline_tdd.py
+++ b/tests/unit/test_text_pipeline_tdd.py
@@ -20,16 +20,14 @@ class TestTextPipelineBasicFunctionality:
 
         assert pipeline.llm_provider is None
         assert pipeline.enable_cleaning is True
-        assert pipeline.enable_natural_formatting is True
 
     def test_text_pipeline_creation_with_custom_settings(self):
         """Should create text pipeline with custom configuration."""
         mock_llm = Mock()
-        pipeline = TextPipeline(llm_provider=mock_llm, enable_cleaning=False, enable_natural_formatting=False)
+        pipeline = TextPipeline(llm_provider=mock_llm, enable_cleaning=False)
 
         assert pipeline.llm_provider == mock_llm
         assert pipeline.enable_cleaning is False
-        assert pipeline.enable_natural_formatting is False
 
     def test_text_pipeline_implements_interface(self):
         """Should properly implement ITextPipeline interface."""
@@ -38,7 +36,6 @@ class TestTextPipelineBasicFunctionality:
 
         # Check all interface methods are implemented
         assert hasattr(pipeline, "clean_text")
-        assert hasattr(pipeline, "enhance_with_natural_formatting")
         assert hasattr(pipeline, "split_into_sentences")
 
 
@@ -164,45 +161,66 @@ class TestTextCleaningTDD:
         assert result.value == "Text with spacing."
 
 
-class TestNaturalFormattingTDD:
-    """TDD tests for natural formatting functionality."""
+class TestNoPauseMarkupInjectionTDD:
+    """The pipeline must not invent punctuation to fake speech pauses.
 
-    def test_natural_formatting_disabled_returns_original(self):
-        """Should return original text when natural formatting is disabled."""
-        pipeline = TextPipeline(enable_natural_formatting=False)
+    Measured against Piper: "." and ".." are phonetically identical, and "..."
+    erases the sentence boundary entirely (espeak-ng merges the words), which
+    also suppresses the inter-sentence silence. See issue #58.
+    """
 
-        text = "This is plain text."
-        result = pipeline.enhance_with_natural_formatting(text)
+    def test_cleaning_does_not_double_sentence_punctuation(self):
+        """Basic cleanup must leave sentence-ending periods alone."""
+        pipeline = TextPipeline(enable_cleaning=False)
+
+        result = pipeline.clean_text("First sentence. Second sentence. Third sentence.")
+
+        assert result.is_success
+        assert result.value is not None
+        assert result.value == "First sentence. Second sentence. Third sentence."
+        assert ".." not in result.value
+
+    def test_cleaning_does_not_inject_ellipses_after_section_headers(self):
+        """Section headers must not gain trailing dots - they destroy the boundary."""
+        pipeline = TextPipeline(enable_cleaning=False)
+
+        result = pipeline.clean_text("Abstract. This paper presents a method. Introduction. We begin here.")
+
+        assert result.is_success
+        assert result.value is not None
+        assert "..." not in result.value
+        assert "Abstract. This paper" in result.value
+
+    def test_abbreviations_survive_cleaning_intact(self):
+        """Trailing dots on abbreviations broke sentence splitting downstream."""
+        pipeline = TextPipeline(enable_cleaning=False)
+
+        result = pipeline.clean_text("We follow Smith et al. and cf. Jones for the setup.")
+
+        assert result.is_success
+        assert result.value is not None
+        assert "et al.." not in result.value
+        assert "cf.." not in result.value
+
+    def test_cleaning_does_not_double_commas(self):
+        """Doubled commas are a no-op acoustically and corrupt the text."""
+        pipeline = TextPipeline(enable_cleaning=False)
+
+        result = pipeline.clean_text("In this paper, we present a method.")
+
+        assert result.is_success
+        assert result.value is not None
+        assert ",," not in result.value
+
+    def test_ordinary_punctuation_is_preserved(self):
+        """Commas, semicolons, colons and dashes carry the rhythm - keep them."""
+        pipeline = TextPipeline(enable_cleaning=False)
+
+        text = "We tested three cases: the first, the second; and the third."
+        result = pipeline.clean_text(text)
 
         assert result.is_success
         assert result.value == text
-
-    def test_natural_formatting_adds_natural_pauses(self):
-        """Should add natural formatting for better speech."""
-        pipeline = TextPipeline(enable_natural_formatting=True)
-
-        text = "Abstract This is the abstract. Introduction This is the intro."
-        result = pipeline.enhance_with_natural_formatting(text)
-
-        # Should add natural formatting (dots, etc.) not SSML
-        assert result.is_success
-        assert result.value is not None
-        assert "Abstract" in result.value
-        assert "Introduction" in result.value
-        # Natural formatting uses dots, not SSML tags
-        assert "..." in result.value
-
-    def test_natural_formatting_handles_empty_text(self):
-        """Should handle empty or whitespace-only text."""
-        pipeline = TextPipeline(enable_natural_formatting=True)
-
-        empty_result = pipeline.enhance_with_natural_formatting("")
-        assert empty_result.is_failure  # Empty text should fail
-
-        whitespace_result = pipeline.enhance_with_natural_formatting("   ")
-        assert whitespace_result.is_success
-        assert whitespace_result.value is not None
-        assert whitespace_result.value.strip() == ""
 
 
 class TestSentenceSplittingTDD:
@@ -312,7 +330,7 @@ class TestTextPipelineIntegrationTDD:
             "This paper presents our algorithm methodology. We propose a new approach."
         )
 
-        pipeline = TextPipeline(llm_provider=mock_llm, enable_cleaning=True, enable_natural_formatting=True)
+        pipeline = TextPipeline(llm_provider=mock_llm, enable_cleaning=True)
 
         raw_text = "Raw   academic   text about algorithms."
 
@@ -322,27 +340,20 @@ class TestTextPipelineIntegrationTDD:
         assert cleaned.value is not None
         assert "algorithm" in cleaned.value
 
-        # Enhance with natural formatting
-        enhanced = pipeline.enhance_with_natural_formatting(cleaned.value)
-        # Natural formatting adds double dots between sentences and commas after academic phrases
-        assert enhanced.is_success
-        assert enhanced.value is not None
-        assert ".. " in enhanced.value or ",," in enhanced.value  # Natural formatting enhancements
-
         # Split into sentences
-        sentences = pipeline.split_into_sentences(enhanced.value)
+        sentences = pipeline.split_into_sentences(cleaned.value)
         assert sentences.is_success
         assert sentences.value is not None
         assert len(sentences.value) >= 1
 
-        # Verify no SSML in results (natural formatting only)
+        # Cleaning must not introduce markup
         all_text = " ".join(sentences.value)
         assert "<emphasis>" not in all_text
         assert "algorithm" in all_text
 
     def test_pipeline_consistency_across_operations(self):
         """Should maintain text consistency through all operations."""
-        pipeline = TextPipeline(enable_cleaning=False, enable_natural_formatting=True)
+        pipeline = TextPipeline(enable_cleaning=False)
 
         original_text = "Test sentence one. Test sentence two."
 
@@ -350,10 +361,7 @@ class TestTextPipelineIntegrationTDD:
         cleaned = pipeline.clean_text(original_text)
         assert cleaned.is_success
         assert cleaned.value is not None
-        enhanced = pipeline.enhance_with_natural_formatting(cleaned.value)
-        assert enhanced.is_success
-        assert enhanced.value is not None
-        sentences = pipeline.split_into_sentences(enhanced.value)
+        sentences = pipeline.split_into_sentences(cleaned.value)
         assert sentences.is_success
         assert sentences.value is not None
 
@@ -363,43 +371,34 @@ class TestTextPipelineIntegrationTDD:
         assert final.is_success
         assert final.value is not None
 
-        # Should preserve core content (may have formatting enhancements like double dots)
+        # Should preserve core content verbatim
         assert any("Test sentence one" in sentence for sentence in final.value)
         assert any("Test sentence two" in sentence for sentence in final.value)
 
     def test_pipeline_handles_large_text_efficiently(self):
         """Should handle larger text blocks without issues."""
-        pipeline = TextPipeline(enable_cleaning=False, enable_natural_formatting=True)
+        pipeline = TextPipeline(enable_cleaning=False)
 
         # Create larger text block
         large_text = " ".join([f"Sentence number {i} with content." for i in range(100)])
 
-        # Should process without errors
-        result = pipeline.enhance_with_natural_formatting(large_text)
-        assert result.is_success
-        assert result.value is not None
-        assert len(result.value) >= len(large_text)  # Should have added natural formatting
-
-        sentences = pipeline.split_into_sentences(result.value)
+        sentences = pipeline.split_into_sentences(large_text)
         assert sentences.is_success
         assert sentences.value is not None
         assert len(sentences.value) == 100  # Should split correctly
 
     def test_pipeline_with_all_features_disabled(self):
         """Should work correctly with all enhancement features disabled."""
-        pipeline = TextPipeline(enable_cleaning=False, enable_natural_formatting=False)
+        pipeline = TextPipeline(enable_cleaning=False)
 
         text = "Simple   text   with   spacing."
 
         cleaned = pipeline.clean_text(text)
         assert cleaned.is_success
         assert cleaned.value is not None
-        enhanced = pipeline.enhance_with_natural_formatting(cleaned.value)
-        assert enhanced.is_success
-        assert enhanced.value is not None
 
-        # Should still do basic cleanup but no natural formatting
-        assert enhanced.value == "Simple text with spacing."
+        # Basic cleanup only - text is passed through to TTS verbatim otherwise
+        assert cleaned.value == "Simple text with spacing."
 
     def test_pipeline_error_resilience(self):
         """Should be resilient to various error conditions."""
@@ -409,9 +408,6 @@ class TestTextPipelineIntegrationTDD:
         # Should handle empty strings gracefully
         clean_empty = pipeline.clean_text("")
         assert clean_empty.is_failure  # Empty text should fail for cleaning
-
-        enhance_empty = pipeline.enhance_with_natural_formatting("")
-        assert enhance_empty.is_failure  # Empty text should fail for enhancement
 
         split_empty = pipeline.split_into_sentences("")
         assert split_empty.is_success
@@ -459,7 +455,10 @@ class TestTextPipelinePromptGenerationTDD:
 
         assert "Clean this text for text-to-speech" in prompt
         assert "Page numbers, headers, footers" in prompt
-        assert "natural punctuation" in prompt
+        assert "Restore correct punctuation" in prompt
+        # Speech rhythm comes from ordinary punctuation; invented pause markup is a
+        # no-op at best and erases sentence boundaries at worst.
+        assert 'Do NOT add "..."' in prompt
 
 
 class TestTextPipelineEdgeCasesTDD:
@@ -517,15 +516,3 @@ class TestTextPipelineEdgeCasesTDD:
         assert result.is_success
         assert result.value is not None
         assert len(result.value) == 0
-
-    def test_handles_mixed_case_section_headers(self):
-        """Should handle section headers in various cases."""
-        pipeline = TextPipeline(enable_natural_formatting=True)
-
-        text = "ABSTRACT This is content. abstract This too. Abstract: Also this."
-        result = pipeline.enhance_with_natural_formatting(text)
-
-        # Should handle different cases of section headers with natural formatting
-        assert result.is_success
-        assert result.value is not None
-        assert "..." in result.value  # Natural formatting uses dots instead of SSML


### PR DESCRIPTION
Speech pacing has never worked because the mechanism used to control it does not exist, and the mechanisms that do exist were never wired up.

Closes #58, closes #59, closes #61.

## The measurements this is based on

All figures from `en_US-lessac-medium` via piper-tts 1.4.1 with `noise_scale=0` and `noise_w_scale=0`, so runs are deterministic.

**Repeated punctuation does nothing.** espeak-ng normalises it away before phonemization:

| Input | Phonemes | Duration |
|---|---|---|
| `significant. We then...` | `...sɪɡnˈɪfɪkənt.` \| `wiː ðˈɛn...` | 2.8793s |
| `significant.. We then...` | identical | 2.8793s |
| `study, we present...` | `stˈʌdi, wiː...` | — |
| `study,, we present...` | identical | — |

**The ellipsis is actively harmful.** It erases the sentence boundary rather than lengthening it:

```
"The results were significant... We then ran a second study."
  -> ['ðə ɹɪzˈʌlts wɜː sɪɡnˈɪfɪkəntwiː ðˈɛn ɹˈæn ɐ sˈɛkənd stˈʌdi.']
```

`sɪɡnˈɪfɪkəntwiː` is one run with no punctuation phoneme. Three sentences joined by `...` collapse from 3 chunks to 1 (3.669s → 2.972s), so the inter-sentence gap is never inserted. The LLM cleaning prompt was explicitly instructing the model to insert `...` for "medium pauses" — asking for the one construct that deletes them.

**Ordinary punctuation is what the synthesizer honours:**

| Punctuation | Duration | Gain |
|---|---|---|
| none | 2.891s | — |
| `,` | 3.181s | +290ms |
| `;` | 3.216s | +325ms |
| `:` | 3.251s | +360ms |
| `—` | 3.216s | +325ms |
| `( )` | 2.891s | +0ms (ignored) |

## Changes

### Remove punctuation-based pause injection (#58)

Deletes `_enhance_with_natural_formatting` and its four helpers — one of which, `_add_natural_emphasis`, returned its input unchanged — plus the `enable_natural_formatting` flag and both call sites.

Beyond buying no pause, the pass corrupted text: `cf.` → `cf..`, `et al.` → `et al..`, which defeated the abbreviation guards in `split_into_sentences` so citations split mid-reference. It also ran **twice** on the timing path (once in `DocumentEngine`, again per chunk in `TimingEngine`), compounding artifacts into `"Abstract. ...  ...   In this paper"`.

The cleaning prompt is rewritten around punctuation **fidelity** rather than invention: re-join sentences broken across line breaks, restore commas PDF extraction dropped, keep the source's own `; : —`, prefer commas or dashes over parentheses, and explicitly do not add `...`.

### Fix the Piper synthesis path (#59)

`_generate_with_python_lib` called `synthesize(text, wav_file)`, but in piper-tts 1.4 the second positional argument is `syn_config`, not a wav file. Reproduced:

```
RAISED: Error # channels not specified
```

It raised on **every** call, was caught behind a `logger.debug`, and fell through to the CLI — spawning a subprocess and reloading the 63MB ONNX model per chunk. Now uses a real `SynthesisConfig`, writes inter-sentence silence between chunks the way piper's own CLI does, and logs the fallback at `warning` so a broken fast path is visible.

`noise_scale`, `noise_w` and `sentence_silence` were documented in `config.example.yaml`, parsed in `system_config.py`, stored on `PiperConfig` — and then dropped. Only `length_scale` ever reached the engine. All four now go through both the library and CLI paths.

Note the field rename this had to get right: our `noise_w` is Piper's `noise_w_scale`.

### Wire the Gemini style prompt (#61)

Gemini takes delivery direction as natural language, not SSML. It turned out `style_prompt` was *already* a `GeminiConfig` field and *already* parsed from `tts.gemini.style_prompt` — the factory simply never passed it and the provider had no parameter for it, so text went out bare. Same failure mode as #59.

Threaded through both sync and async paths with a long-form-reading default; an empty string opts out.

## Verification

`sentence_silence` now produces exactly one gap per sentence boundary (3 sentences, so 2 gaps):

| `sentence_silence` | Duration | Δ from 0.0 |
|---|---|---|
| 0.0 | 4.574s | — |
| 0.2 | 4.974s | +0.400s |
| 0.5 | 5.574s | +1.000s |
| 1.0 | 6.574s | +2.000s |

End-to-end on a cleaned paragraph, with no fallback warning fired (fast path in use):

| Setting | Duration |
|---|---|
| brisk (`length_scale=0.95`, `sentence_silence=0.1`) | 8.945s |
| default (`1.0`, `0.2`) | 9.496s |
| measured (`1.1`, `0.5`) | 11.067s |

Tests: 417 unit + infrastructure, 58 integration, all passing. `make check` clean.

New coverage for the no-injection invariant, `SynthesisConfig` mapping including the `noise_w` rename, and style-prompt behaviour on both sync and async paths. Tests asserting the old behaviour (`assert "..." in result.value`) were deleted.

## Caveats

- **The Gemini change is verified at request-construction level only.** Confirming it audibly changes delivery needs a live API key.
- `TextSegmenter`'s class docstring still advertises SSML tiers that don't exist ("Piper TTS (limited SSML support)", ElevenLabs). Wrong but harmless, and out of scope here.

## Not included

- #60 — structural silence as the real replacement for markup. Larger: chunks are `list[str]` throughout, and this needs them to carry structure.
- #62 — read-along timings currently split a batch's duration *evenly* across its sentences, so a 5-word and a 40-word sentence get identical slots. Piper 1.4's `include_alignments` would replace the guesswork, and depends on the library path fixed here.
