### PR TITLE
refactor: return segments from TTS engines instead of opaque audio

### DIFF
--- a/application/config/system_config.py
+++ b/application/config/system_config.py
@@ -26,7 +26,6 @@ gemini:                 # GeminiConfig - Gemini API settings (optional)
   api_key               # API key (or set GEMINI_API_KEY env var)
   model_name            # Model to use
   style_prompt          # Delivery/tone directive prefixed to the text
-  use_measurement_mode  # Use precise timing vs estimation
 
 files:                  # FileConfig - File storage paths
   upload_folder         # Where uploaded PDFs go
@@ -249,10 +248,6 @@ class SystemConfig:
             ),
             max_retries=cls._parse_int_value(get_config("tts.gemini.max_retries", 3), 3, 1, 10),
             base_retry_delay=cls._parse_int_value(get_config("tts.gemini.base_retry_delay", 16), 16, 1, 60),
-            use_measurement_mode=cls._parse_bool_value(get_config("tts.gemini.use_measurement_mode", False), False),
-            measurement_mode_interval=cls._parse_float_value(
-                get_config("tts.gemini.measurement_mode_interval", 0.8), 0.8, 0.1, 5.0
-            ),
         )
 
     @classmethod

--- a/application/container/service_container.py
+++ b/application/container/service_container.py
@@ -70,9 +70,10 @@ class ServiceContainer(IServiceContainer):
         """Build all core service factories upfront (immutable pattern)."""
         from application.services.document_service import DocumentProcessingService
         from application.services.progress_store import ThreadSafeProgressStore
+        from domain.audio.audio_assembler import AudioAssembler
         from domain.audio.audio_engine import AudioEngine
         from domain.audio.duration_measurer import AudioDurationMeasurer
-        from domain.audio.timing_engine import ITimingEngine, TimingEngine, TimingMode
+        from domain.audio.timing_engine import ITimingEngine, TimingEngine
         from domain.document.document_engine import DocumentEngine
         from domain.interfaces import (
             IAudioDurationMeasurer,
@@ -116,18 +117,20 @@ class ServiceContainer(IServiceContainer):
                 enable_cleaning=self.config.text_processing.enable_cleaning,
                 enable_plain_english=True,
             ),
-            # Timing Engine
+            # Audio Assembler - single owner of gap policy and container writing.
+            # The gap is engine-independent policy; it reads from the Piper block only
+            # because that is where the setting has always lived.
+            AudioAssembler: lambda: AudioAssembler(
+                sentence_gap=self.config.piper.sentence_silence if self.config.piper else 0.2
+            ),
+            # Timing Engine - shares the assembler so the timeline matches the audio
             ITimingEngine: lambda: TimingEngine(
                 tts_engine=self.get("tts_engine"),
                 file_manager=self.get(FileManager),
-                duration_measurer=self.get(IAudioDurationMeasurer),
-                text_pipeline=self.get(ITextPipeline),
-                mode=(
-                    TimingMode.MEASUREMENT
-                    if self.config.gemini and self.config.gemini.use_measurement_mode
-                    else TimingMode.ESTIMATION
+                assembler=self.get(AudioAssembler),
+                request_interval=(
+                    self.config.tts.request_delay_seconds if self.config.tts.engine.value == "gemini" else 0.0
                 ),
-                measurement_interval=self.config.gemini.measurement_mode_interval if self.config.gemini else 10.0,
             ),
             # Audio Engine
             IAudioEngine: lambda: AudioEngine(
@@ -135,6 +138,7 @@ class ServiceContainer(IServiceContainer):
                 file_manager=self.get(FileManager),
                 timing_engine=self.get(ITimingEngine),
                 duration_measurer=self.get(IAudioDurationMeasurer),
+                assembler=self.get(AudioAssembler),
                 max_concurrent=self.config.performance.audio_concurrent_chunks,
                 audio_target_chunk_size=self.config.text_processing.audio_target_chunk_size,
                 audio_max_chunk_size=self.config.text_processing.audio_max_chunk_size,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -25,8 +25,12 @@ tts:
     # Speech speed (1.0 = normal, 0.8 = slower, 1.2 = faster)
     length_scale: 1.0
 
-    # Pause inserted between sentences, in seconds. This is the main cadence
+    # Pause inserted after every sentence, in seconds. This is the main cadence
     # control - raise it for a slower, more deliberate read.
+    #
+    # Applied when the audio is assembled rather than by the engine, so it is
+    # honoured identically between sentences and at chunk boundaries, and the
+    # read-along timeline accounts for it exactly.
     sentence_silence: 0.2
 
     # Synthesis variability. noise_scale affects tone, noise_w affects the

--- a/domain/audio/audio_assembler.py
+++ b/domain/audio/audio_assembler.py
@@ -1,0 +1,120 @@
+# domain/audio/audio_assembler.py - Segment assembly with Result[T] pattern
+"""Assembles synthesized segments into playable audio.
+
+This is the one place that decides what silence goes between segments and how
+samples become a file. Engines return segments; nothing downstream of them
+writes a container or invents a gap.
+
+Keeping it here matters because gaps have to be applied consistently at two
+different seams: between the sentences inside one synthesis call, and between
+the chunks that get concatenated into the finished document. When those two
+decisions lived in different layers, the second one went missing entirely.
+"""
+
+from collections.abc import Sequence
+import io
+import logging
+import wave
+
+from ..errors import ErrorCode, Result, audio_generation_error
+from ..models import SynthesizedSegment, TextSegment
+
+logger = logging.getLogger(__name__)
+
+
+class AudioAssembler:
+    """Turns synthesized segments into WAV bytes and timing metadata.
+
+    Pure functions with no exceptions - all errors returned as Result[T].
+    """
+
+    def __init__(self, sentence_gap: float = 0.2):
+        """Initialize the assembler.
+
+        Args:
+            sentence_gap: Seconds of silence written after each segment. This is the
+                main cadence control; it applies at every segment boundary including
+                the last, so concatenated chunks keep a gap at their seam.
+        """
+        self.sentence_gap = max(0.0, sentence_gap)
+
+    def silence_for(self, segment: SynthesizedSegment) -> bytes:
+        """Silent PCM matching a segment's format, sized to the configured gap."""
+        frames = int(segment.sample_rate * self.sentence_gap)
+        return bytes(frames * segment.frame_size)
+
+    def gap_duration(self) -> float:
+        """Seconds of silence written after each segment."""
+        return self.sentence_gap
+
+    def to_wav(self, segments: Sequence[SynthesizedSegment]) -> Result[bytes]:
+        """Assemble segments into a single WAV, with a gap after each one.
+
+        Returns Result with WAV bytes or error.
+        """
+        if not segments:
+            return Result.failure(audio_generation_error("No segments to assemble"))
+
+        first = segments[0]
+        if not first.frame_size or not first.sample_rate:
+            return Result.failure(audio_generation_error(f"Segment has invalid audio format: {first.sample_rate}Hz"))
+
+        mismatched = [s for s in segments if not s.matches_format(first)]
+        if mismatched:
+            return Result.failure(
+                audio_generation_error(
+                    f"Cannot assemble segments with differing formats "
+                    f"({len(mismatched)} of {len(segments)} do not match {first.sample_rate}Hz)"
+                )
+            )
+
+        try:
+            silence = self.silence_for(first)
+            buffer = io.BytesIO()
+            with wave.open(buffer, "wb") as wav_file:
+                wav_file.setframerate(first.sample_rate)
+                wav_file.setsampwidth(first.sample_width)
+                wav_file.setnchannels(first.channels)
+
+                for segment in segments:
+                    wav_file.writeframes(segment.pcm)
+                    if silence:
+                        wav_file.writeframes(silence)
+
+            return Result.success(buffer.getvalue())
+
+        except Exception as e:
+            return Result.from_exception(e, ErrorCode.AUDIO_GENERATION_FAILED, retryable=False)
+
+    def to_timed_segments(
+        self,
+        segments: Sequence[SynthesizedSegment],
+        chunk_index: int,
+        start_time: float,
+        first_sentence_index: int = 0,
+    ) -> tuple[list[TextSegment], float]:
+        """Map segments onto the timeline using their measured durations.
+
+        The gap after each segment is part of the elapsed time but not part of the
+        segment's own duration, so highlighting clears at the end of the speech
+        rather than lingering through the pause.
+
+        Returns the timed segments and the time immediately after the last gap.
+        """
+        timed: list[TextSegment] = []
+        cursor = start_time
+
+        for offset, segment in enumerate(segments):
+            timed.append(
+                TextSegment(
+                    text=segment.text,
+                    start_time=cursor,
+                    duration=segment.duration,
+                    segment_type="sentence",
+                    chunk_index=chunk_index,
+                    sentence_index=first_sentence_index + offset,
+                )
+            )
+            cursor += segment.duration + self.sentence_gap
+
+        return timed, cursor

--- a/domain/audio/audio_engine.py
+++ b/domain/audio/audio_engine.py
@@ -305,9 +305,7 @@ class AudioEngine(IAudioEngine):
             chunk_time = chunk_end - chunk_start
 
             if result.is_success and result.value:
-                logger.debug(
-                    "Chunk %d completed in %.2fs (%d segments)", chunk_num, chunk_time, len(result.value)
-                )
+                logger.debug("Chunk %d completed in %.2fs (%d segments)", chunk_num, chunk_time, len(result.value))
                 return list(result.value)
             else:
                 error_msg = result.error if result.is_failure else "No audio data"

--- a/domain/audio/audio_engine.py
+++ b/domain/audio/audio_engine.py
@@ -13,8 +13,9 @@ from typing import TYPE_CHECKING, Any
 
 from ..errors import Result, audio_generation_error
 from ..interfaces import IAudioDurationMeasurer, IAudioEngine, IFileManager, ITTSEngine
-from ..models import TimedAudioResult
+from ..models import SynthesizedSegment, TimedAudioResult
 from ..text.chunking_strategy import ChunkingMode, IChunkingStrategy, create_chunking_strategy
+from .audio_assembler import AudioAssembler
 
 logger = logging.getLogger(__name__)
 
@@ -39,10 +40,12 @@ class AudioEngine(IAudioEngine):
         audio_max_chunk_size: int = 3000,
         enable_async: bool = True,
         chunking_strategy: IChunkingStrategy | None = None,
+        assembler: AudioAssembler | None = None,
     ):
         self.tts_engine = tts_engine
         self.file_manager = file_manager
         self.timing_engine = timing_engine
+        self.assembler = assembler or AudioAssembler()
         self.duration_measurer = duration_measurer
         self.max_concurrent = max_concurrent
         self.audio_target_chunk_size = audio_target_chunk_size
@@ -94,20 +97,23 @@ class AudioEngine(IAudioEngine):
             # Generate audio using sync or async based on config
             if self.enable_async:
                 logger.debug("Using async processing for simple audio generation")
-                audio_chunks = self._generate_chunks_with_new_async_interface(processed_chunks)
+                segments = self._generate_chunks_with_new_async_interface(processed_chunks)
             else:
                 logger.debug("Using synchronous processing for simple audio generation")
-                audio_chunks = self._generate_chunks_sync(processed_chunks)
+                segments = self._generate_chunks_sync(processed_chunks)
 
-            if not audio_chunks:
+            if not segments:
                 logger.warning("No successful audio chunks generated")
                 return Result.success(TimedAudioResult(audio_files=[], combined_mp3=None, timing_data=None))
 
-            # Combine audio chunks
-            combined_audio = self._combine_wav_chunks(audio_chunks)
-
-            if not combined_audio:
+            # One assembly point for the whole document, so the gap between chunks is
+            # the same gap as between sentences inside a chunk
+            assembled = self.assembler.to_wav(segments)
+            if assembled.is_failure or not assembled.value:
+                logger.error("Failed to assemble audio segments: %s", assembled.error)
                 return Result.success(TimedAudioResult(audio_files=[], combined_mp3=None, timing_data=None))
+
+            combined_audio = assembled.value
 
             # Save audio file as WAV first (since TTS engines typically generate WAV)
             temp_wav_filename = f"{output_filename}_temp.wav"
@@ -143,8 +149,8 @@ class AudioEngine(IAudioEngine):
             logger.exception("Simple audio generation failed: %s", e)
             return Result.failure(audio_generation_error(f"Simple audio generation failed: {e}"))
 
-    def _generate_chunks_with_new_async_interface(self, processed_chunks: list[str]) -> list[bytes]:
-        """Generate audio chunks using the new async interface with true parallelism.
+    def _generate_chunks_with_new_async_interface(self, processed_chunks: list[str]) -> list[SynthesizedSegment]:
+        """Generate segments using the async interface with true parallelism.
 
         Pure function - returns empty list on error.
         """
@@ -157,26 +163,26 @@ class AudioEngine(IAudioEngine):
             logger.exception("Async processing failed: %s", e)
             return []
 
-    def _generate_chunks_sync(self, processed_chunks: list[str]) -> list[bytes]:
-        """Generate audio chunks synchronously.
+    def _generate_chunks_sync(self, processed_chunks: list[str]) -> list[SynthesizedSegment]:
+        """Generate segments synchronously.
 
-        Pure function - returns list of successful chunks.
+        Pure function - returns the flattened segments of all successful chunks.
         """
-        audio_chunks = []
+        segments: list[SynthesizedSegment] = []
 
         for i, chunk in enumerate(processed_chunks, 1):
             logger.debug("Processing chunk %d/%d (%d chars)", i, len(processed_chunks), len(chunk))
 
-            result = self.tts_engine.generate_audio_data(chunk)
+            result = self.tts_engine.synthesize(chunk)
             if result.is_success and result.value is not None:
-                audio_chunks.append(result.value)
-                logger.debug("Chunk %d completed (%d bytes)", i, len(result.value))
+                segments.extend(result.value)
+                logger.debug("Chunk %d completed (%d segments)", i, len(result.value))
             else:
                 logger.warning("Chunk %d failed: %s", i, result.error)
 
-        return audio_chunks
+        return segments
 
-    async def _process_chunks_async(self, processed_chunks: list[str]) -> list[bytes]:
+    async def _process_chunks_async(self, processed_chunks: list[str]) -> list[SynthesizedSegment]:
         """Orchestrate parallel chunk processing with proper async coordination.
 
         Returns list of successful audio chunks.
@@ -201,9 +207,11 @@ class AudioEngine(IAudioEngine):
         logger.debug("Starting parallel processing at %.2f", start_time)
         return {"start_time": start_time}
 
-    def _create_chunk_tasks(self, processed_chunks: list[str]) -> list[Coroutine[Any, Any, bytes | None]]:
+    def _create_chunk_tasks(
+        self, processed_chunks: list[str]
+    ) -> list[Coroutine[Any, Any, list[SynthesizedSegment] | None]]:
         """Create async tasks for all valid chunks."""
-        tasks: list[Coroutine[Any, Any, bytes | None]] = []
+        tasks: list[Coroutine[Any, Any, list[SynthesizedSegment] | None]] = []
         for i, chunk in enumerate(processed_chunks):
             if not chunk.strip():
                 continue
@@ -214,35 +222,41 @@ class AudioEngine(IAudioEngine):
         return tasks
 
     async def _execute_tasks_with_rate_limiting(
-        self, tasks: list[Coroutine[Any, Any, bytes | None]]
-    ) -> list[bytes | None | BaseException]:
+        self, tasks: list[Coroutine[Any, Any, list[SynthesizedSegment] | None]]
+    ) -> list[list[SynthesizedSegment] | None | BaseException]:
         """Execute tasks with semaphore-based rate limiting."""
         # Apply rate limiting
         semaphore = asyncio.Semaphore(self.max_concurrent)
         limited_tasks = [self._limited_chunk_processing(semaphore, task) for task in tasks]
 
         # Execute all tasks concurrently
-        results: list[bytes | None | BaseException] = await asyncio.gather(*limited_tasks, return_exceptions=True)
+        results: list[list[SynthesizedSegment] | None | BaseException] = await asyncio.gather(
+            *limited_tasks, return_exceptions=True
+        )
         return results
 
     def _process_async_results(
         self,
-        results: list[bytes | None | BaseException],
+        results: list[list[SynthesizedSegment] | None | BaseException],
         processed_chunks: list[str],
         timing_context: dict[str, float],
-    ) -> list[bytes]:
-        """Process results, calculate metrics, and filter successful chunks."""
+    ) -> list[SynthesizedSegment]:
+        """Process results, calculate metrics, and flatten successful chunks.
+
+        asyncio.gather preserves input order, so flattening here keeps the segments
+        in document order even though the chunks completed out of order.
+        """
         import time
 
         end_time = time.time()
         total_time = end_time - timing_context["start_time"]
         logger.info("Parallel processing completed in %.2f seconds", total_time)
 
-        # Filter successful results (immutable) - cast is safe because we filter out non-bytes
-        audio_chunks: list[bytes] = [
-            result
+        audio_chunks: list[SynthesizedSegment] = [
+            segment
             for result in results
-            if not isinstance(result, Exception) and result is not None and isinstance(result, bytes)
+            if not isinstance(result, BaseException) and result is not None
+            for segment in result
         ]
 
         # Handle failed chunks logging
@@ -251,7 +265,7 @@ class AudioEngine(IAudioEngine):
                 logger.warning("Chunk %d failed with exception: %s", i + 1, result)
 
         logger.info(
-            "Successfully processed %d/%d chunks in %.2fs",
+            "Successfully produced %d segments from %d chunks in %.2fs",
             len(audio_chunks),
             len(processed_chunks),
             total_time,
@@ -267,8 +281,8 @@ class AudioEngine(IAudioEngine):
         return audio_chunks
 
     async def _limited_chunk_processing(
-        self, semaphore: asyncio.Semaphore, task: Awaitable[bytes | None]
-    ) -> bytes | None:
+        self, semaphore: asyncio.Semaphore, task: Awaitable[list[SynthesizedSegment] | None]
+    ) -> list[SynthesizedSegment] | None:
         """Apply semaphore limiting to chunk processing."""
         async with semaphore:
             result = await task
@@ -276,7 +290,9 @@ class AudioEngine(IAudioEngine):
             await asyncio.sleep(self.base_delay)
             return result
 
-    async def _process_single_chunk_async(self, chunk: str, chunk_num: int, total_chunks: int) -> bytes | None:
+    async def _process_single_chunk_async(
+        self, chunk: str, chunk_num: int, total_chunks: int
+    ) -> list[SynthesizedSegment] | None:
         """Process a single chunk asynchronously."""
         import time
 
@@ -284,14 +300,15 @@ class AudioEngine(IAudioEngine):
         logger.debug("Starting chunk %d/%d (%d chars)", chunk_num, total_chunks, len(chunk))
 
         try:
-            # Use the new async interface
-            result = await self.tts_engine.generate_audio_data_async(chunk)
+            result = await self.tts_engine.synthesize_async(chunk)
             chunk_end = time.time()
             chunk_time = chunk_end - chunk_start
 
             if result.is_success and result.value:
-                logger.debug("Chunk %d completed in %.2fs (%d bytes)", chunk_num, chunk_time, len(result.value))
-                return result.value
+                logger.debug(
+                    "Chunk %d completed in %.2fs (%d segments)", chunk_num, chunk_time, len(result.value)
+                )
+                return list(result.value)
             else:
                 error_msg = result.error if result.is_failure else "No audio data"
                 logger.warning("Chunk %d failed in %.2fs: %s", chunk_num, chunk_time, error_msg)
@@ -311,58 +328,6 @@ class AudioEngine(IAudioEngine):
         from .duration_measurer import AudioDurationMeasurer
 
         return AudioDurationMeasurer().get_duration(file_path)
-
-    def _combine_wav_chunks(self, audio_chunks: list[bytes]) -> bytes:
-        """Combine multiple audio chunks.
-
-        If WAV (RIFF header), uses wave module to combine properly.
-        Otherwise (e.g. MP3), concatenates bytes directly.
-        """
-        try:
-            import io
-            import wave
-
-            if not audio_chunks:
-                return b""
-
-            if len(audio_chunks) == 1:
-                return audio_chunks[0]
-
-            # Check for RIFF header to determine if it's WAV
-            if not audio_chunks[0].startswith(b"RIFF"):
-                logger.debug("Chunks do not appear to be WAV (no RIFF header), using direct concatenation")
-                return b"".join(audio_chunks)
-
-            # Read the first chunk to get audio parameters
-            first_chunk = io.BytesIO(audio_chunks[0])
-            with wave.open(first_chunk, "rb") as first_wav:
-                params = first_wav.getparams()
-
-            # Create output buffer
-            output_buffer = io.BytesIO()
-
-            # Write combined WAV file
-            with wave.open(output_buffer, "wb") as output_wav:
-                output_wav.setparams(params)
-
-                # Append audio data from each chunk
-                for chunk_data in audio_chunks:
-                    chunk_buffer = io.BytesIO(chunk_data)
-                    try:
-                        with wave.open(chunk_buffer, "rb") as chunk_wav:
-                            frames = chunk_wav.readframes(chunk_wav.getnframes())
-                            output_wav.writeframes(frames)
-                    except wave.Error:
-                        # Fallback for mixed content? Should not happen if first chunk was RIFF
-                        logger.warning("Failed to read chunk as WAV during combination")
-                        continue
-
-            return output_buffer.getvalue()
-
-        except Exception as e:
-            logger.exception("Error combining audio chunks: %s", e)
-            # Fallback: return the first chunk or concatenation if combination fails
-            return b"".join(audio_chunks) if audio_chunks else b""
 
     def combine_audio_files(self, file_paths: list[str], output_path: str) -> Result[str]:
         """Combine multiple audio files using ffmpeg.
@@ -556,9 +521,12 @@ class AudioEngine(IAudioEngine):
                 return None
 
     def _call_tts_engine(self, text: str) -> Result[bytes]:
-        """Call TTS engine (blocking operation)."""
+        """Synthesize and assemble a standalone audio file (blocking operation)."""
         try:
-            return self.tts_engine.generate_audio_data(text)
+            result = self.tts_engine.synthesize(text)
+            if result.is_failure or not result.value:
+                return Result.failure(result.error or audio_generation_error("TTS engine returned no segments"))
+            return self.assembler.to_wav(result.value)
         except Exception as e:
             return Result.failure(audio_generation_error(f"TTS engine call failed: {e!s}"))
 

--- a/domain/audio/timing_engine.py
+++ b/domain/audio/timing_engine.py
@@ -3,97 +3,40 @@
 
 No exceptions thrown - all errors returned as Result[T].
 
-Timing Algorithm Overview
-=========================
+Timing Algorithm
+================
 
-The timing engine generates word-level timestamps for read-along synchronization.
-Two modes are available depending on TTS engine capabilities:
+Word-level timestamps for read-along synchronization come from the segments the
+TTS engine returns, not from estimation.
 
-Estimation Mode (default)
--------------------------
-Used when TTS engine doesn't provide native timestamps (e.g., Piper TTS).
+1. Synthesize each text chunk, which yields one segment per sentence carrying
+   both the sentence text and its audio.
+2. Lay the segments out on a timeline using their measured durations, plus the
+   inter-sentence gap the assembler will write between them.
+3. Assemble all segments into one audio file.
 
-Algorithm:
-1. Generate audio for entire text chunk
-2. Get total audio duration from WAV header
-3. Split text into sentences, then words
-4. Estimate word timings using character-weighted distribution:
-   - word_duration = (word_chars / total_chars) * total_duration
-   - Accounts for punctuation pauses (adds small delay after . ! ?)
-5. Generate TextSegment objects with estimated start_time and duration
+Because the same AudioAssembler decides both the gap in the timeline and the gap
+in the audio, the two cannot drift apart.
 
-Estimation formula:
-   characters_per_second = total_chars / total_duration
-   word_duration = len(word) / characters_per_second
-   pause_after = 0.3 if word ends with [.!?] else 0.1
-
-Measurement Mode
-----------------
-Used when TTS engine provides native word timestamps (e.g., some cloud APIs).
-
-Algorithm:
-1. Call TTS engine's generate_audio_with_timestamps() method
-2. Extract native timestamp data from response
-3. Map timestamps directly to TextSegment objects
-4. No estimation needed - uses actual audio timings
-
-Trade-offs:
-- Estimation: Works with any TTS, ~10-15% timing variance, faster processing
-- Measurement: Precise timings, requires API support, may have rate limits
-
-Configuration:
-- mode: TimingMode.ESTIMATION or TimingMode.MEASUREMENT
-- measurement_interval: Batch size for measurement mode (seconds between batches)
-
-Output:
-- TimedAudioResult containing:
-  - audio_files: List of generated audio file paths
-  - combined_mp3: Path to combined audio file (if multiple chunks)
-  - timing_data: TimingMetadata with word-level TextSegments
+Engines with no internal structure (Gemini) return a single segment per chunk, so
+timing is chunk-granular rather than sentence-granular. That is a real limitation
+of the engine, and it is visible in the data rather than hidden behind an
+estimate that looks precise.
 """
 
 from abc import ABC, abstractmethod
 from contextlib import suppress
-import dataclasses
-from enum import Enum
 import logging
 from pathlib import Path
+import subprocess  # nosec B404
 import time
-from typing import TYPE_CHECKING, Optional
 
 from ..errors import ErrorCode, Result, audio_generation_error
-from ..interfaces import IAudioDurationMeasurer, IFileManager, ITTSEngine
-from ..models import TextSegment, TimedAudioResult, TimingMetadata
-
-if TYPE_CHECKING:
-    from ..interfaces import ITextPipeline
+from ..interfaces import IFileManager, ITTSEngine
+from ..models import SynthesizedSegment, TextSegment, TimedAudioResult, TimingMetadata
+from .audio_assembler import AudioAssembler
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass(frozen=True)
-class ChunkProcessingResult:
-    """Result of processing a single text chunk."""
-
-    temp_files: list[str]
-    text_segments: list[TextSegment]
-    final_cumulative_time: float
-
-
-@dataclasses.dataclass(frozen=True)
-class BatchProcessingResult:
-    """Result of processing a batch of sentences."""
-
-    temp_file: str | None
-    text_segments: list[TextSegment]
-    final_cumulative_time: float
-
-
-class TimingMode(Enum):
-    """Available timing modes."""
-
-    ESTIMATION = "estimation"  # Fast mathematical calculation (for engines without native timestamps)
-    MEASUREMENT = "measurement"  # Precise timing from actual audio (for engines with timestamp support)
 
 
 class ITimingEngine(ABC):
@@ -114,175 +57,75 @@ class TimingEngine(ITimingEngine):
         self,
         tts_engine: ITTSEngine,
         file_manager: IFileManager,
-        duration_measurer: IAudioDurationMeasurer,
-        text_pipeline: Optional["ITextPipeline"] = None,
-        mode: TimingMode = TimingMode.ESTIMATION,
-        measurement_interval: float = 0.8,
+        assembler: AudioAssembler | None = None,
+        request_interval: float = 0.0,
     ):
+        """Initialize the timing engine.
+
+        Args:
+            tts_engine: Engine that turns text into segments.
+            file_manager: Sink for the generated audio.
+            assembler: Owns gap policy and container writing. Must be the same policy
+                used for the audio itself, or the timeline and the audio disagree.
+            request_interval: Minimum seconds between synthesis calls. Only matters
+                for rate-limited cloud engines; leave at 0 for local ones.
+        """
         self.tts_engine = tts_engine
         self.file_manager = file_manager
-        self.duration_measurer = duration_measurer
-        self.text_pipeline = text_pipeline
-        self.mode = mode
-        self.measurement_interval = measurement_interval
+        self.assembler = assembler or AudioAssembler()
+        self.request_interval = request_interval
         self.last_api_call = 0.0
 
-        # Optimize timing mode for engine capabilities
-        if mode == TimingMode.ESTIMATION and not hasattr(tts_engine, "generate_audio_with_timestamps"):
-            logger.debug("%s: No native timestamps, switching to measurement mode", tts_engine.__class__.__name__)
-            self.mode = TimingMode.MEASUREMENT
-
     def generate_with_timing(self, text_chunks: list[str], output_filename: str) -> Result[TimedAudioResult]:
-        """Main entry point - routes to appropriate timing strategy.
-
-        Returns Result with timing data or error.
-        """
+        """Synthesize all chunks and lay them out on a measured timeline."""
         try:
-            if self.mode == TimingMode.ESTIMATION:
-                return self._generate_with_estimation(text_chunks, output_filename)
-            else:  # self.mode == TimingMode.MEASUREMENT
-                return self._generate_with_measurement(text_chunks, output_filename)
-        except Exception as e:
-            return Result.from_exception(e, ErrorCode.AUDIO_GENERATION_FAILED, retryable=True)
+            all_segments: list[SynthesizedSegment] = []
+            timed_segments: list[TextSegment] = []
+            cursor = 0.0
 
-    def _generate_with_estimation(self, text_chunks: list[str], output_filename: str) -> Result[TimedAudioResult]:
-        """Fast timing using mathematical calculations.
-
-        Returns Result with timing data or error.
-        """
-        if not hasattr(self.tts_engine, "generate_audio_with_timestamps"):
-            # Engine doesn't support native timestamps, use measurement mode instead
-            return self._generate_with_measurement(text_chunks, output_filename)
-
-        logger.debug("TimingEngine: Using estimation mode with native engine timestamps")
-
-        try:
-            # Process chunks individually to respect size limits
-            all_audio_files = []
-            all_text_segments = []
-            cumulative_time = 0.0
-
-            logger.debug("TimingEngine: Processing %d chunks individually", len(text_chunks))
-
-            for i, chunk in enumerate(text_chunks):
-                logger.debug("TimingEngine: Processing chunk %d/%d (%d chars)", i + 1, len(text_chunks), len(chunk))
-
-                # Check chunk size
-                if len(chunk) > 3000:
-                    logger.warning(
-                        "TimingEngine: Chunk %d too large (%d chars), falling back to measurement mode",
-                        i + 1,
-                        len(chunk),
-                    )
-                    return self._generate_with_measurement(text_chunks, output_filename)
-
+            for chunk_index, chunk in enumerate(text_chunks):
                 if not chunk.strip():
                     continue
 
-                # Use engine's native timestamping for this chunk
-                result = self.tts_engine.generate_audio_with_timestamps(chunk)
+                self._apply_rate_limiting()
 
-                if result.is_failure:
-                    logger.warning("TimingEngine: Engine failed for chunk %d: %s", i + 1, result.error)
+                result = self.tts_engine.synthesize(chunk)
+                if result.is_failure or not result.value:
+                    logger.warning("TimingEngine: Chunk %d failed: %s", chunk_index + 1, result.error)
                     continue
 
-                audio_data, text_segments = result.value
+                segments = list(result.value)
+                logger.debug("TimingEngine: Chunk %d produced %d segments", chunk_index + 1, len(segments))
 
-                if not audio_data:
-                    continue
-
-                # Save audio file for this chunk
-                audio_filename = f"{output_filename}_chunk_{i}.mp3"
-                audio_path = self.file_manager.save_output_file(audio_data, audio_filename)
-
-                if audio_path:
-                    all_audio_files.append(audio_filename)
-
-                    # Adjust timestamps for this chunk relative to previous chunks (immutable)
-                    if text_segments:
-                        adjusted_segments = [
-                            dataclasses.replace(segment, start_time=segment.start_time + cumulative_time)
-                            for segment in text_segments
-                        ]
-                        all_text_segments.extend(adjusted_segments)
-
-                        # Update cumulative time
-                        last_segment = text_segments[-1]
-                        cumulative_time += last_segment.end_time
-
-            if not all_audio_files:
-                return Result.failure(audio_generation_error("No audio files generated in estimation mode"))
-
-            # Create combined MP3
-            combined_filename = f"{output_filename}_timed.mp3"
-            combined_path = self._combine_audio_chunks(all_audio_files, combined_filename)
-
-            if not combined_path:
-                return Result.failure(audio_generation_error("Failed to combine audio chunks"))
-
-            # Create timing metadata
-            timing_metadata = TimingMetadata(
-                total_duration=cumulative_time,
-                text_segments=all_text_segments,
-                audio_files=all_audio_files,
-            )
-
-            return Result.success(
-                TimedAudioResult(
-                    audio_files=all_audio_files,
-                    combined_mp3=combined_filename,
-                    timing_data=timing_metadata,
+                chunk_timed, cursor = self.assembler.to_timed_segments(
+                    segments, chunk_index=chunk_index, start_time=cursor
                 )
+                all_segments.extend(segments)
+                timed_segments.extend(chunk_timed)
+
+            if not all_segments:
+                return Result.failure(audio_generation_error("No audio generated for any chunk"))
+
+            assembled = self.assembler.to_wav(all_segments)
+            if assembled.is_failure or not assembled.value:
+                return Result.failure(assembled.error or audio_generation_error("Failed to assemble audio"))
+
+            combined_filename = f"{output_filename}_timed.mp3"
+            write_result = self._write_mp3(assembled.value, output_filename, combined_filename)
+            if write_result.is_failure:
+                return Result.failure(write_result.error)  # type: ignore[arg-type]
+
+            timing_metadata = TimingMetadata(
+                total_duration=cursor,
+                text_segments=timed_segments,
+                audio_files=[combined_filename],
             )
 
-        except Exception as e:
-            return Result.from_exception(e, ErrorCode.AUDIO_GENERATION_FAILED, retryable=True)
-
-    def _generate_with_measurement(self, text_chunks: list[str], output_filename: str) -> Result[TimedAudioResult]:
-        """Precise timing through actual audio measurement.
-
-        Returns Result with timing data or error.
-        """
-        logger.debug("TimingEngine: Using measurement mode for accurate timing extraction")
-
-        try:
-            all_temp_files = []
-            all_text_segments = []
-            cumulative_time = 0.0
-
-            # Process each chunk
-            for i, chunk in enumerate(text_chunks):
-                chunk_result = self._process_chunk_with_measurement(chunk, i, cumulative_time)
-
-                if chunk_result is None:
-                    continue
-
-                all_temp_files.extend(chunk_result.temp_files)
-                all_text_segments.extend(chunk_result.text_segments)
-                cumulative_time = chunk_result.final_cumulative_time
-
-            if not all_temp_files:
-                return Result.failure(audio_generation_error("No audio files generated in measurement mode"))
-
-            # Create final combined audio file
-            combined_filename = f"{output_filename}_timed.mp3"
-            combined_path = self._combine_audio_chunks(all_temp_files, combined_filename)
-
-            # Clean up temporary files
-            for temp_file in all_temp_files:
-                with suppress(OSError, FileNotFoundError):
-                    temp_path = Path(self.file_manager.get_output_dir()) / temp_file
-                    if temp_path.exists():
-                        temp_path.unlink()
-
-            if not combined_path:
-                return Result.failure(audio_generation_error("Failed to combine audio files"))
-
-            # Create timing metadata
-            timing_metadata = TimingMetadata(
-                total_duration=cumulative_time,
-                text_segments=all_text_segments,
-                audio_files=[combined_filename],
+            logger.info(
+                "TimingEngine: %d segments over %.2fs from %d chunks",
+                len(timed_segments),
+                cursor,
+                len(text_chunks),
             )
 
             return Result.success(
@@ -296,185 +139,52 @@ class TimingEngine(ITimingEngine):
         except Exception as e:
             return Result.from_exception(e, ErrorCode.AUDIO_GENERATION_FAILED, retryable=True)
 
-    def _process_chunk_with_measurement(
-        self, chunk: str, chunk_index: int, cumulative_time: float
-    ) -> ChunkProcessingResult | None:
-        """Process a single chunk with measurement mode.
-
-        Returns ChunkProcessingResult or None on failure.
-        """
-        try:
-            # Split into sentences if pipeline is available
-            if self.text_pipeline:
-                sentences_result = self.text_pipeline.split_into_sentences(chunk)
-                if sentences_result.is_success and sentences_result.value is not None:
-                    sentences = sentences_result.value
-                else:
-                    sentences = [chunk]
-            else:
-                sentences = [chunk]
-
-            logger.debug("TimingEngine: Chunk %d has %d sentences", chunk_index + 1, len(sentences))
-
-            # Process in batches for efficiency
-            batch_size = 5
-            temp_files = []
-            text_segments = []
-
-            for batch_start in range(0, len(sentences), batch_size):
-                batch_end = min(batch_start + batch_size, len(sentences))
-                batch = sentences[batch_start:batch_end]
-
-                logger.debug(
-                    "  Processing batch %d (sentences %d-%d)", batch_start // batch_size + 1, batch_start + 1, batch_end
-                )
-
-                batch_result = self._process_sentence_batch(batch, chunk_index, batch_start, cumulative_time)
-
-                if batch_result and batch_result.temp_file:
-                    temp_files.append(batch_result.temp_file)
-                    text_segments.extend(batch_result.text_segments)
-                    cumulative_time = batch_result.final_cumulative_time
-
-            return ChunkProcessingResult(
-                temp_files=temp_files,
-                text_segments=text_segments,
-                final_cumulative_time=cumulative_time,
-            )
-
-        except Exception as e:
-            logger.error("TimingEngine: Error processing chunk %d: %s", chunk_index, e, exc_info=True)
-            return None
-
-    def _process_sentence_batch(
-        self, sentences: list[str], chunk_index: int, batch_start: int, cumulative_time: float
-    ) -> BatchProcessingResult | None:
-        """Process a batch of sentences for timing.
-
-        Returns BatchProcessingResult or None on failure.
-        """
-        try:
-            batch_text = " ".join(sentences)
-
-            # Rate limiting
-            self._apply_rate_limiting()
-
-            # Generate audio for batch
-            audio_result = self.tts_engine.generate_audio_data(batch_text)
-            if audio_result.is_failure or not audio_result.value:
-                logger.warning("    Failed to generate audio for batch")
-                return None
-
-            # Save temporary audio file
-            temp_filename = f"temp_chunk_{chunk_index}_batch_{batch_start}.wav"
-            temp_path = self.file_manager.save_output_file(audio_result.value, temp_filename)
-
-            if not temp_path:
-                return None
-
-            # Measure audio duration
-            duration_result = self.duration_measurer.get_duration(temp_path)
-
-            if duration_result.is_failure or duration_result.value is None:
-                # Estimate duration fallback
-                duration = len(batch_text) * 0.06  # Rough estimate
-            else:
-                duration = duration_result.value
-
-            logger.debug("    Audio duration: %.2fs", duration)
-
-            # Create timing segments for each sentence
-            text_segments = []
-            sentence_duration = duration / len(sentences) if sentences else 0
-
-            for i, sentence in enumerate(sentences):
-                segment = TextSegment(
-                    text=sentence,
-                    start_time=cumulative_time + (i * sentence_duration),
-                    duration=sentence_duration,
-                    segment_type="sentence",
-                    chunk_index=chunk_index,
-                    sentence_index=batch_start + i,
-                )
-                text_segments.append(segment)
-
-            return BatchProcessingResult(
-                temp_file=temp_filename,
-                text_segments=text_segments,
-                final_cumulative_time=cumulative_time + duration,
-            )
-
-        except Exception as e:
-            logger.error("    Error processing batch: %s", e, exc_info=True)
-            return None
-
     def _apply_rate_limiting(self) -> None:
-        """Apply rate limiting between API calls.
+        """Space out synthesis calls for rate-limited engines."""
+        if self.request_interval <= 0:
+            return
 
-        Pure function - no exceptions thrown.
-        """
-        current_time = time.time()
-        time_since_last = current_time - self.last_api_call
-
-        if time_since_last < self.measurement_interval:
-            sleep_time = self.measurement_interval - time_since_last
-            logger.debug("    Rate limiting: sleeping %.2fs", sleep_time)
+        elapsed = time.time() - self.last_api_call
+        if elapsed < self.request_interval:
+            sleep_time = self.request_interval - elapsed
+            logger.debug("TimingEngine: Rate limiting, sleeping %.2fs", sleep_time)
             time.sleep(sleep_time)
 
         self.last_api_call = time.time()
 
-    def _combine_audio_chunks(self, audio_files: list[str], output_filename: str) -> str | None:
-        """Combine multiple audio files into one.
+    def _write_mp3(self, wav_bytes: bytes, output_filename: str, mp3_filename: str) -> Result[str]:
+        """Save assembled audio and transcode it to MP3."""
+        temp_wav_name = f"{output_filename}_timed_temp.wav"
+        temp_wav_path = self.file_manager.save_output_file(wav_bytes, temp_wav_name)
+        if not temp_wav_path:
+            return Result.failure(audio_generation_error("Failed to save assembled audio"))
 
-        Returns output path or None on failure.
-        """
+        mp3_path = Path(self.file_manager.get_output_dir()) / mp3_filename
+
         try:
-            if not audio_files:
-                return None
-
-            # Get full paths
-            full_paths = []
-            for audio_file in audio_files:
-                full_path = Path(self.file_manager.get_output_dir()) / audio_file
-                if full_path.exists():
-                    full_paths.append(str(full_path))
-
-            if not full_paths:
-                return None
-
-            # Use audio engine's combine function
-            output_path = Path(self.file_manager.get_output_dir()) / output_filename
-
-            # Create a minimal audio engine just for combining
-            # This is a bit of a hack but avoids circular dependencies
-            import subprocess  # nosec B404
-
-            if len(full_paths) == 1:
-                # Just copy the single file
-                import shutil
-
-                shutil.copy2(full_paths[0], str(output_path))
-                return output_filename
-
-            # Use ffmpeg directly for combining
-            list_file = str(output_path) + ".list"
-            with Path(list_file).open("w") as f:
-                for path in full_paths:
-                    f.write(f"file '{path}'\n")
-
-            cmd = ["ffmpeg", "-f", "concat", "-safe", "0", "-i", list_file, "-c", "copy", str(output_path), "-y"]
+            cmd = [
+                "ffmpeg",
+                "-i",
+                temp_wav_path,
+                "-codec:a",
+                "libmp3lame",
+                "-b:a",
+                "192k",
+                "-ar",
+                "44100",
+                str(mp3_path),
+                "-y",
+            ]
             result = subprocess.run(cmd, capture_output=True, timeout=300)
 
-            # Clean up list file
-            with suppress(OSError, FileNotFoundError):
-                Path(list_file).unlink()
+            if result.returncode != 0:
+                return Result.failure(audio_generation_error(f"ffmpeg conversion failed: {result.stderr.decode()}"))
 
-            if result.returncode == 0:
-                return output_filename
-            else:
-                logger.error("ffmpeg combine failed: %s", result.stderr.decode())
-                return None
+            return Result.success(str(mp3_path))
 
         except Exception as e:
-            logger.error("TimingEngine: Error combining audio files: %s", e, exc_info=True)
-            return None
+            return Result.failure(audio_generation_error(f"MP3 conversion failed: {e}"))
+
+        finally:
+            with suppress(OSError, FileNotFoundError):
+                Path(temp_wav_path).unlink()

--- a/domain/config/tts_config.py
+++ b/domain/config/tts_config.py
@@ -21,8 +21,6 @@ class GeminiConfig:
     min_request_interval: float = 2.0
     max_retries: int = 3
     base_retry_delay: int = 16
-    use_measurement_mode: bool = False
-    measurement_mode_interval: float = 0.8
 
 
 @dataclass(frozen=True)

--- a/domain/interfaces.py
+++ b/domain/interfaces.py
@@ -5,10 +5,19 @@ implementations, facilitating testing and modularity.
 """
 
 from abc import ABC, abstractmethod
+from collections.abc import Sequence
 from typing import Any
 
 from .errors import Result
-from .models import CleanupStats, PageRange, PDFInfo, PdfPageText, ProcessingRequest, TimedAudioResult
+from .models import (
+    CleanupStats,
+    PageRange,
+    PDFInfo,
+    PdfPageText,
+    ProcessingRequest,
+    SynthesizedSegment,
+    TimedAudioResult,
+)
 
 # --- Core Service Interfaces ---
 
@@ -89,24 +98,30 @@ class IPdfTextExtractor(ABC):
 
 
 class ITTSEngine(ABC):
-    """Interface for a Text-to-Speech engine."""
+    """Interface for a Text-to-Speech engine.
+
+    Engines return segments, not a finished audio file. Engines that synthesize
+    sentence by sentence (Piper) return one segment per sentence, so the text and
+    its audio stay associated and timing can be measured rather than estimated.
+    Engines with no internal structure (Gemini) return a single segment.
+
+    Turning segments into a playable file - inter-sentence silence, level
+    handling, container format - is AudioAssembler's job, not an engine's.
+    """
 
     @abstractmethod
-    def generate_audio_data(self, text_to_speak: str) -> Result[bytes]:
-        """Generates raw audio data from text.
+    def synthesize(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Synthesize text into one or more segments.
 
         Returns:
-            Result[bytes]: Success with audio content or failure with error.
+            Result[Sequence[SynthesizedSegment]]: Segments in playback order, or failure.
         """
 
     @abstractmethod
-    async def generate_audio_data_async(self, text_to_speak: str) -> Result[bytes]:
-        """Generates raw audio data from text asynchronously.
+    async def synthesize_async(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Synthesize text asynchronously.
 
-        For engines that don't support native async, this can wrap the sync method.
-
-        Returns:
-            Result[bytes]: Success with audio content or failure with error.
+        Engines without native async support may wrap the sync method.
         """
 
     @abstractmethod

--- a/domain/models.py
+++ b/domain/models.py
@@ -109,6 +109,45 @@ class CleanupResult:
 
 
 @dataclass(frozen=True)
+class SynthesizedSegment:
+    """One stretch of speech and the text that produced it.
+
+    This is what TTS engines return. Keeping the text/audio correspondence intact
+    is the point: durations here are measured, not estimated, so read-along timing
+    does not have to guess at how a blob of audio divides between its sentences.
+
+    `pcm` is raw samples with no container - assembling those into a playable file,
+    and deciding what silence goes between them, belongs to AudioAssembler.
+    """
+
+    text: str
+    pcm: bytes
+    sample_rate: int
+    sample_width: int  # bytes per sample
+    channels: int
+
+    @property
+    def frame_size(self) -> int:
+        """Bytes per frame across all channels."""
+        return self.sample_width * self.channels
+
+    @property
+    def duration(self) -> float:
+        """Measured duration in seconds."""
+        if not self.frame_size or not self.sample_rate:
+            return 0.0
+        return (len(self.pcm) / self.frame_size) / self.sample_rate
+
+    def matches_format(self, other: "SynthesizedSegment") -> bool:
+        """Whether two segments can be concatenated without resampling."""
+        return (
+            self.sample_rate == other.sample_rate
+            and self.sample_width == other.sample_width
+            and self.channels == other.channels
+        )
+
+
+@dataclass(frozen=True)
 class TextSegment:
     """Represents a segment of text with timing information."""
 

--- a/infrastructure/tts/gemini_tts_provider.py
+++ b/infrastructure/tts/gemini_tts_provider.py
@@ -1,6 +1,7 @@
 # infrastructure/tts/gemini_tts_provider.py
 """Gemini TTS Provider implementation using Google Gen AI SDK."""
 
+from collections.abc import Sequence
 import io
 import logging
 import wave
@@ -10,6 +11,7 @@ from google.genai import types
 
 from domain.errors import Result, tts_engine_error
 from domain.interfaces import ITTSEngine
+from domain.models import SynthesizedSegment
 
 logger = logging.getLogger(__name__)
 
@@ -70,8 +72,12 @@ class GeminiTTSProvider(ITTSEngine):
             return text
         return f"{self.style_prompt}\n\n{text}"
 
-    def generate_audio_data(self, text: str) -> Result[bytes]:
-        """Generate audio data from text using Gemini."""
+    def synthesize(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Synthesize text into a single segment.
+
+        Gemini returns one undifferentiated stretch of audio with no sentence
+        boundaries, so there is exactly one segment covering the whole text.
+        """
         # Check for deferred initialization errors
         if self._initialization_error:
             logger.error("Gemini TTS initialization failed: %s", self._initialization_error)
@@ -100,14 +106,14 @@ class GeminiTTSProvider(ITTSEngine):
             response = self.client.models.generate_content(model=self.model_name, contents=prompt, config=config)
             logger.debug("Gemini API call successful, extracting audio from response")
 
-            return self._extract_audio_from_response(response)
+            return self._segments_from_response(text, response)
 
         except Exception as e:
             logger.exception("Gemini TTS generation failed")
             return Result.failure(tts_engine_error(f"Gemini TTS failed: {e}"))
 
-    async def generate_audio_data_async(self, text: str) -> Result[bytes]:
-        """Generate audio data asynchronously."""
+    async def synthesize_async(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Synthesize asynchronously using Gemini's async client."""
         # Check for deferred initialization errors
         if self._initialization_error:
             logger.error("Gemini TTS initialization failed: %s", self._initialization_error)
@@ -133,14 +139,16 @@ class GeminiTTSProvider(ITTSEngine):
                 model=self.model_name, contents=prompt, config=config
             )
 
-            return self._extract_audio_from_response(response)
+            return self._segments_from_response(text, response)
 
         except Exception as e:
             logger.exception("Gemini Async TTS generation failed")
             return Result.failure(tts_engine_error(f"Gemini Async TTS failed: {e}"))
 
-    def _extract_audio_from_response(self, response: types.GenerateContentResponse) -> Result[bytes]:
-        """Extract audio bytes from Gemini response."""
+    def _segments_from_response(
+        self, text: str, response: types.GenerateContentResponse
+    ) -> Result[Sequence[SynthesizedSegment]]:
+        """Build a single segment from a Gemini response."""
         num_candidates = len(response.candidates) if response.candidates else 0
         logger.debug("Extracting audio from response (candidates=%d)", num_candidates)
         if not response.candidates:
@@ -164,35 +172,54 @@ class GeminiTTSProvider(ITTSEngine):
                     part.inline_data.mime_type,
                     len(audio_data),
                 )
-                # If PCM, add WAV header
                 if "pcm" in part.inline_data.mime_type:
-                    # Extract sample rate if possible, otherwise default to 24000
-                    sample_rate = 24000
-                    if "rate=" in part.inline_data.mime_type:
-                        try:
-                            rate_str = part.inline_data.mime_type.split("rate=")[1]
-                            sample_rate = int(rate_str.split(";")[0])
-                        except (IndexError, ValueError):
-                            pass
+                    sample_rate = self._parse_sample_rate(part.inline_data.mime_type)
+                    logger.debug("PCM audio detected (sample_rate=%d)", sample_rate)
+                    return Result.success(
+                        [
+                            SynthesizedSegment(
+                                text=text,
+                                pcm=audio_data,
+                                sample_rate=sample_rate,
+                                sample_width=2,  # Gemini PCM is 16-bit
+                                channels=1,
+                            )
+                        ]
+                    )
 
-                    logger.debug("PCM audio detected, adding WAV header (sample_rate=%d)", sample_rate)
-                    return Result.success(self._add_wav_header(audio_data, sample_rate))
-
-                return Result.success(audio_data)
+                # Anything else arrives as an encoded container we cannot treat as PCM
+                return self._segment_from_container(text, audio_data)
 
         return Result.failure(tts_engine_error("No audio data found in Gemini response"))
 
-    def _add_wav_header(
-        self, pcm_data: bytes, sample_rate: int = 24000, channels: int = 1, bit_depth: int = 16
-    ) -> bytes:
-        """Add WAV header to raw PCM data."""
-        with io.BytesIO() as wav_io:
-            with wave.open(wav_io, "wb") as wav_file:
-                wav_file.setnchannels(channels)
-                wav_file.setsampwidth(bit_depth // 8)
-                wav_file.setframerate(sample_rate)
-                wav_file.writeframes(pcm_data)
-            return wav_io.getvalue()
+    @staticmethod
+    def _parse_sample_rate(mime_type: str, default: int = 24000) -> int:
+        """Read the sample rate out of a PCM mime type, falling back to the default."""
+        if "rate=" not in mime_type:
+            return default
+        try:
+            return int(mime_type.split("rate=")[1].split(";")[0])
+        except (IndexError, ValueError):
+            return default
+
+    @staticmethod
+    def _segment_from_container(text: str, audio_data: bytes) -> Result[Sequence[SynthesizedSegment]]:
+        """Unwrap a WAV container into a segment; other formats are unsupported."""
+        try:
+            with wave.open(io.BytesIO(audio_data), "rb") as wav_file:
+                return Result.success(
+                    [
+                        SynthesizedSegment(
+                            text=text,
+                            pcm=wav_file.readframes(wav_file.getnframes()),
+                            sample_rate=wav_file.getframerate(),
+                            sample_width=wav_file.getsampwidth(),
+                            channels=wav_file.getnchannels(),
+                        )
+                    ]
+                )
+        except (wave.Error, EOFError) as e:
+            return Result.failure(tts_engine_error(f"Gemini returned audio in an unsupported format: {e}"))
 
     def supports_ssml(self) -> bool:
         """Whether this engine supports SSML."""

--- a/infrastructure/tts/piper_tts_provider.py
+++ b/infrastructure/tts/piper_tts_provider.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from contextlib import suppress
 
 # Import logger for debugging home user issues
@@ -16,6 +17,8 @@ import urllib.request
 from domain.config import PiperConfig
 from domain.errors import Result, tts_engine_error
 from domain.interfaces import ITTSEngine
+from domain.models import SynthesizedSegment
+from infrastructure.tts.text_segmenter import TextSegmenter
 
 if TYPE_CHECKING:
     from piper.config import SynthesisConfig
@@ -51,10 +54,11 @@ class PiperTTSProvider(ITTSEngine):
             project_root: Secure project root path (for binary lookup)
 
         Note: Constructor never raises exceptions. Initialization errors
-        are stored and returned on first call to generate_audio_data().
+        are stored and returned on first call to synthesize().
         """
         self.config = config
         self.output_format = "wav"
+        self.segmenter = TextSegmenter()
         self.model_path = config.model_path
         self.config_path = config.config_path
         self.project_root = project_root or str(Path.cwd())  # Secure default
@@ -105,26 +109,31 @@ class PiperTTSProvider(ITTSEngine):
 
     # === ITTSEngine Implementation ===
 
-    def generate_audio_data(self, text_to_speak: str) -> Result[bytes]:
-        """Generate audio data using Piper TTS."""
-        logger.info(f"Starting Piper TTS generation for {len(text_to_speak)} characters")
+    def synthesize(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Synthesize text into one segment per sentence.
+
+        Sentences are split here rather than left to espeak so that each segment
+        carries the exact source text that produced its audio - that correspondence
+        is what lets timing be measured instead of estimated.
+        """
+        logger.info("Starting Piper TTS generation for %d characters", len(text))
 
         # Check for deferred initialization errors
         if self._initialization_error:
             logger.error("Piper TTS initialization failed: %s", self._initialization_error)
             return Result.failure(tts_engine_error(self._initialization_error))
 
-        if not text_to_speak or text_to_speak.strip() == "":
+        if not text or text.strip() == "":
             logger.warning("Empty text provided to Piper TTS")
             return Result.failure(tts_engine_error("Empty text provided"))
 
         # Skip error messages
-        if text_to_speak.startswith(("LLM cleaning skipped", "Error:", "Could not convert")):
+        if text.startswith(("LLM cleaning skipped", "Error:", "Could not convert")):
             logger.warning("Skipping TTS generation for error message")
             return Result.failure(tts_engine_error("Cannot generate audio from error message"))
 
         # Strip ALL SSML tags for Piper (it doesn't support any SSML)
-        processed_text = self._process_text_for_piper(text_to_speak)
+        processed_text = self._process_text_for_piper(text)
         if not processed_text.strip():
             logger.error("Text processing resulted in empty content after SSML removal")
             return Result.failure(tts_engine_error("Text processing resulted in empty content"))
@@ -140,34 +149,31 @@ class PiperTTSProvider(ITTSEngine):
 
         try:
             if self.piper_method == "python_library" and self.voice_instance is not None:
-                logger.info("Using Piper Python library for TTS generation")  # type: ignore[unreachable]
-                audio_data = self._generate_with_python_lib(processed_text)
+                logger.debug("Using Piper Python library for TTS generation")  # type: ignore[unreachable]
+                segments = self._synthesize_with_python_lib(processed_text)
             else:
-                logger.info("Using Piper command line for TTS generation")
-                audio_data = self._generate_with_command_line(processed_text)
+                logger.debug("Using Piper command line for TTS generation")
+                segments = self._synthesize_with_command_line(processed_text)
 
-            if not audio_data:
+            if not segments:
                 logger.error("TTS engine returned no audio data")
                 return Result.failure(tts_engine_error("TTS engine returned no audio data"))
 
-            logger.info(f"Piper TTS generation successful - produced {len(audio_data)} bytes of audio")
-            return Result.success(audio_data)
+            logger.info("Piper TTS produced %d segment(s)", len(segments))
+            return Result.success(segments)
         except subprocess.TimeoutExpired as timeout_ex:
             timeout_duration = getattr(timeout_ex, "timeout", 30)
-            logger.error(f"Piper command timed out after {timeout_duration} seconds")
+            logger.error("Piper command timed out after %s seconds", timeout_duration)
             return Result.failure(tts_engine_error(f"Piper command timed out after {timeout_duration} seconds"))
         except Exception as e:
-            logger.error(f"Piper TTS generation failed: {type(e).__name__}: {e}", exc_info=True)
+            logger.error("Piper TTS generation failed: %s: %s", type(e).__name__, e, exc_info=True)
             return Result.failure(tts_engine_error(f"Audio generation failed: {e!s}"))
 
-    async def generate_audio_data_async(self, text_to_speak: str) -> Result[bytes]:
-        """Async wrapper for Piper TTS - calls sync method in thread pool.
-
-        Piper is a local engine and doesn't have native async support.
-        """
+    async def synthesize_async(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Async wrapper - Piper is local and has no native async support."""
         import asyncio
 
-        return await asyncio.to_thread(self.generate_audio_data, text_to_speak)
+        return await asyncio.to_thread(self.synthesize, text)
 
     def supports_ssml(self) -> bool:
         """Return True if this engine supports SSML markup."""
@@ -305,55 +311,80 @@ class PiperTTSProvider(ITTSEngine):
             normalize_audio=False,
         )
 
-    def _generate_with_python_lib(self, text: str) -> bytes:
-        """Generate using the Piper Python library.
+    def _synthesize_with_python_lib(self, text: str) -> list[SynthesizedSegment]:
+        """Synthesize one segment per sentence using the Piper Python library.
 
-        Piper emits one audio chunk per sentence and applies no inter-sentence silence,
-        so the gaps are written here. Note this deliberately differs from piper's own
-        CLI, which only gaps *within* one synthesize() call: our callers concatenate
-        these blobs, so a trailing gap is what keeps the seam between two chunks from
-        running two sentences together.
+        Each sentence is handed to Piper separately so the returned segment carries
+        the exact text that produced it. Piper may split a sentence further; those
+        sub-chunks are joined back into the one segment we asked for.
         """
         try:
-            from io import BytesIO
-            import wave
-
             if self.voice_instance is None:
                 raise Exception("Voice instance not initialized")
 
             syn_config = self._build_synthesis_config()
+            sentences = self.segmenter.split_into_sentences(text) or [text]
 
-            # Materialize before opening the wave writer: raising inside the `with` would
-            # be masked by Wave_write.close() failing on unset params, replacing the real
-            # error with a confusing "# channels not specified".
-            chunks = list(self.voice_instance.synthesize(text, syn_config))
-            if not chunks:
+            segments: list[SynthesizedSegment] = []
+            for sentence in sentences:
+                if not sentence.strip():
+                    continue
+
+                chunks = list(self.voice_instance.synthesize(sentence, syn_config))
+                if not chunks:
+                    logger.debug("Piper produced no audio for sentence: %r", sentence[:60])
+                    continue
+
+                first = chunks[0]
+                segments.append(
+                    SynthesizedSegment(
+                        text=sentence,
+                        pcm=b"".join(chunk.audio_int16_bytes for chunk in chunks),
+                        sample_rate=first.sample_rate,
+                        sample_width=first.sample_width,
+                        channels=first.sample_channels,
+                    )
+                )
+
+            if not segments:
                 raise Exception("Piper produced no audio chunks")
 
-            first = chunks[0]
-            # 16-bit silence sized to the configured inter-sentence gap
-            silence_bytes = bytes(
-                int(first.sample_rate * self.config.sentence_silence) * first.sample_width * first.sample_channels
-            )
-
-            audio_buffer = BytesIO()
-            with wave.open(audio_buffer, "wb") as wav_file:
-                wav_file.setframerate(first.sample_rate)
-                wav_file.setsampwidth(first.sample_width)
-                wav_file.setnchannels(first.sample_channels)
-
-                for chunk in chunks:
-                    wav_file.writeframes(chunk.audio_int16_bytes)
-                    if silence_bytes:
-                        wav_file.writeframes(silence_bytes)
-
-            return audio_buffer.getvalue()
+            return segments
 
         except Exception as e:
             # Loud on purpose: a silent fall-through here means every chunk pays for a
             # subprocess and a full model reload, which is easy to miss.
             logger.warning("Piper Python library generation failed, falling back to command line: %s", e)
-            return self._generate_with_command_line(text)
+            return self._synthesize_with_command_line(text)
+
+    def _synthesize_with_command_line(self, text: str) -> list[SynthesizedSegment]:
+        """Synthesize via the CLI, which can only return one undifferentiated segment.
+
+        The CLI emits a finished WAV with no sentence boundaries, so timing on this
+        path is necessarily coarser than the library path.
+        """
+        wav_bytes = self._generate_with_command_line(text)
+        segment = self._segment_from_wav(text, wav_bytes)
+        return [segment] if segment else []
+
+    @staticmethod
+    def _segment_from_wav(text: str, wav_bytes: bytes) -> SynthesizedSegment | None:
+        """Unwrap a WAV container into a segment."""
+        import io
+        import wave
+
+        try:
+            with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+                return SynthesizedSegment(
+                    text=text,
+                    pcm=wav_file.readframes(wav_file.getnframes()),
+                    sample_rate=wav_file.getframerate(),
+                    sample_width=wav_file.getsampwidth(),
+                    channels=wav_file.getnchannels(),
+                )
+        except (wave.Error, EOFError) as e:
+            logger.error("Piper CLI produced audio that could not be read as WAV: %s", e)
+            return None
 
     def _generate_with_command_line(self, text: str) -> bytes:
         """Generate using command line."""
@@ -379,8 +410,6 @@ class PiperTTSProvider(ITTSEngine):
                 str(self.config.noise_scale),
                 "--noise_w",
                 str(self.config.noise_w),
-                "--sentence_silence",
-                str(self.config.sentence_silence),
             ]
 
             if self.config_path and Path(self.config_path).exists():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,16 @@ from application.config.processing_configs import LLMConfig, OCRConfig, Performa
 from application.config.system_config import SystemConfig
 from domain.config.tts_config import PiperConfig, TTSConfig, TTSEngine
 from domain.errors import Result
-from domain.models import PageRange, PDFInfo, ProcessingRequest, TextSegment, TimedAudioResult, TimingMetadata
+from domain.models import (
+    PageRange,
+    PDFInfo,
+    ProcessingRequest,
+    SynthesizedSegment,
+    TextSegment,
+    TimedAudioResult,
+    TimingMetadata,
+)
+from tests.test_helpers import fake_segments
 
 # === Core Test Fixtures ===
 
@@ -101,12 +110,14 @@ def mock_tts_engine():
     """Professional mock TTS engine with realistic behavior."""
     mock = MagicMock()
 
-    def generate_audio_side_effect(text: str) -> Result[bytes]:
-        # Simulate realistic audio generation
-        audio_size = len(text) * 10  # 10 bytes per character
-        return Result.success(b"fake_audio_" + b"x" * audio_size)
+    def synthesize_side_effect(text: str) -> Result[list[SynthesizedSegment]]:
+        return Result.success(fake_segments(text))
 
-    mock.generate_audio_data.side_effect = generate_audio_side_effect
+    async def synthesize_async_side_effect(text: str) -> Result[list[SynthesizedSegment]]:
+        return Result.success(fake_segments(text))
+
+    mock.synthesize.side_effect = synthesize_side_effect
+    mock.synthesize_async.side_effect = synthesize_async_side_effect
     mock.supports_ssml.return_value = True
 
     return mock

--- a/tests/infrastructure/tts/test_gemini_tts_provider.py
+++ b/tests/infrastructure/tts/test_gemini_tts_provider.py
@@ -171,9 +171,7 @@ class TestGeminiTTSProviderSyncGeneration:
         provider = basic_gemini_provider
         mock_client = Mock()
         pcm = b"\x00\x01" * 100
-        mock_client.models.generate_content.return_value = make_audio_response(
-            pcm, mime_type="audio/pcm;rate=24000"
-        )
+        mock_client.models.generate_content.return_value = make_audio_response(pcm, mime_type="audio/pcm;rate=24000")
         provider.client = mock_client
 
         result = provider.synthesize("Hello")
@@ -225,9 +223,7 @@ class TestGeminiTTSProviderAsyncGeneration:
         assert result.value[0].text == "Test text for async generation"
 
     @pytest.mark.asyncio
-    async def test_synthesize_async_handles_api_exception(
-        self, basic_gemini_provider: GeminiTTSProvider
-    ) -> None:
+    async def test_synthesize_async_handles_api_exception(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Async API exceptions should become failure Results."""
         provider = basic_gemini_provider
         mock_client = Mock()

--- a/tests/infrastructure/tts/test_gemini_tts_provider.py
+++ b/tests/infrastructure/tts/test_gemini_tts_provider.py
@@ -79,7 +79,7 @@ class TestGeminiTTSProviderInitialization:
             mock_client_class.side_effect = ValueError("bad key")
 
             provider = GeminiTTSProvider(model_name="gemini-1.5-flash", api_key="bad", voice_name="Kore")
-            result = provider.generate_audio_data("Hello")
+            result = provider.synthesize("Hello")
 
             assert result.is_failure
             assert result.error is not None
@@ -98,18 +98,18 @@ class TestGeminiTTSProviderInterfaces:
 class TestGeminiTTSProviderTextValidation:
     """Test text input validation for TTS generation."""
 
-    def test_generate_audio_data_rejects_empty_text(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+    def test_synthesize_rejects_empty_text(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should reject empty text input."""
-        result = basic_gemini_provider.generate_audio_data("")
+        result = basic_gemini_provider.synthesize("")
 
         assert result.is_failure
         assert result.error is not None
         assert result.error.code == ErrorCode.TTS_ENGINE_ERROR
         assert "Empty text provided" in str(result.error.details)
 
-    def test_generate_audio_data_rejects_whitespace_only(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+    def test_synthesize_rejects_whitespace_only(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should reject whitespace-only text."""
-        result = basic_gemini_provider.generate_audio_data("   \n\t  ")
+        result = basic_gemini_provider.synthesize("   \n\t  ")
 
         assert result.is_failure
         assert result.error is not None
@@ -119,7 +119,7 @@ class TestGeminiTTSProviderTextValidation:
     def test_empty_text_error_consistency(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should consistently reject all empty inputs."""
         for empty_input in ["", "   ", "\n\n", "\t\t", "  \n  \t  "]:
-            result = basic_gemini_provider.generate_audio_data(empty_input)
+            result = basic_gemini_provider.synthesize(empty_input)
             assert result.is_failure
             assert result.error is not None
             assert result.error.code == ErrorCode.TTS_ENGINE_ERROR
@@ -129,38 +129,8 @@ class TestGeminiTTSProviderTextValidation:
 class TestGeminiTTSProviderSyncGeneration:
     """Test synchronous TTS generation with a mocked client."""
 
-    def test_generate_audio_data_success(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+    def test_synthesize_success(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should return audio bytes from the API response."""
-        provider = basic_gemini_provider
-        mock_client = Mock()
-        mock_client.models.generate_content.return_value = make_audio_response(b"mp3_bytes")
-        provider.client = mock_client
-
-        result = provider.generate_audio_data("Hello, this is a test.")
-
-        assert result.is_success
-        assert result.value == b"mp3_bytes"
-        mock_client.models.generate_content.assert_called_once()
-        call_kwargs = mock_client.models.generate_content.call_args.kwargs
-        assert call_kwargs["model"] == "gemini-1.5-flash"
-        # Text is sent with the delivery directive prefixed - Gemini's only prosody control
-        assert call_kwargs["contents"] == f"{DEFAULT_STYLE_PROMPT}\n\nHello, this is a test."
-
-    def test_generate_audio_data_handles_unicode(self, basic_gemini_provider: GeminiTTSProvider) -> None:
-        """Should pass Unicode text through to the API."""
-        provider = basic_gemini_provider
-        mock_client = Mock()
-        mock_client.models.generate_content.return_value = make_audio_response(b"audio")
-        provider.client = mock_client
-
-        unicode_text = "Héllo wörld! 你好世界 🌍"
-        result = provider.generate_audio_data(unicode_text)
-
-        assert result.is_success
-        assert mock_client.models.generate_content.call_args.kwargs["contents"].endswith(unicode_text)
-
-    def test_generate_audio_data_wraps_pcm_in_wav(self, basic_gemini_provider: GeminiTTSProvider) -> None:
-        """PCM responses should get a WAV header."""
         provider = basic_gemini_provider
         mock_client = Mock()
         mock_client.models.generate_content.return_value = make_audio_response(
@@ -168,20 +138,62 @@ class TestGeminiTTSProviderSyncGeneration:
         )
         provider.client = mock_client
 
-        result = provider.generate_audio_data("Hello")
+        result = provider.synthesize("Hello, this is a test.")
 
         assert result.is_success
         assert result.value is not None
-        assert result.value[:4] == b"RIFF"
+        # Gemini has no sentence structure, so the whole chunk is one segment
+        assert len(result.value) == 1
+        assert result.value[0].text == "Hello, this is a test."
+        mock_client.models.generate_content.assert_called_once()
+        call_kwargs = mock_client.models.generate_content.call_args.kwargs
+        assert call_kwargs["model"] == "gemini-1.5-flash"
+        # Text is sent with the delivery directive prefixed - Gemini's only prosody control
+        assert call_kwargs["contents"] == f"{DEFAULT_STYLE_PROMPT}\n\nHello, this is a test."
 
-    def test_generate_audio_data_handles_api_exception(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+    def test_synthesize_handles_unicode(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+        """Should pass Unicode text through to the API."""
+        provider = basic_gemini_provider
+        mock_client = Mock()
+        mock_client.models.generate_content.return_value = make_audio_response(
+            b"\x00\x01" * 100, mime_type="audio/pcm;rate=24000"
+        )
+        provider.client = mock_client
+
+        unicode_text = "Héllo wörld! 你好世界 🌍"
+        result = provider.synthesize(unicode_text)
+
+        assert result.is_success
+        assert mock_client.models.generate_content.call_args.kwargs["contents"].endswith(unicode_text)
+
+    def test_pcm_returned_as_raw_samples(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+        """PCM stays raw - wrapping it in a container is AudioAssembler's job now."""
+        provider = basic_gemini_provider
+        mock_client = Mock()
+        pcm = b"\x00\x01" * 100
+        mock_client.models.generate_content.return_value = make_audio_response(
+            pcm, mime_type="audio/pcm;rate=24000"
+        )
+        provider.client = mock_client
+
+        result = provider.synthesize("Hello")
+
+        assert result.is_success
+        assert result.value is not None
+        segment = result.value[0]
+        assert segment.pcm == pcm
+        assert segment.sample_rate == 24000
+        assert segment.sample_width == 2
+        assert segment.channels == 1
+
+    def test_synthesize_handles_api_exception(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """API exceptions should become failure Results, not raise."""
         provider = basic_gemini_provider
         mock_client = Mock()
         mock_client.models.generate_content.side_effect = RuntimeError("quota exceeded")
         provider.client = mock_client
 
-        result = provider.generate_audio_data("Hello")
+        result = provider.synthesize("Hello")
 
         assert result.is_failure
         assert result.error is not None
@@ -192,24 +204,28 @@ class TestGeminiTTSProviderAsyncGeneration:
     """Test async TTS generation with a mocked client."""
 
     @pytest.mark.asyncio
-    async def test_generate_audio_data_async_success(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+    async def test_synthesize_async_success(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Should generate audio asynchronously via the aio client."""
         provider = basic_gemini_provider
         mock_client = Mock()
 
+        pcm = b"\x00\x01" * 100
+
         async def fake_generate(**_kwargs: object) -> SimpleNamespace:
-            return make_audio_response(b"async_audio")
+            return make_audio_response(pcm, mime_type="audio/pcm;rate=24000")
 
         mock_client.aio.models.generate_content = fake_generate
         provider.client = mock_client
 
-        result = await provider.generate_audio_data_async("Test text for async generation")
+        result = await provider.synthesize_async("Test text for async generation")
 
         assert result.is_success
-        assert result.value == b"async_audio"
+        assert result.value is not None
+        assert result.value[0].pcm == pcm
+        assert result.value[0].text == "Test text for async generation"
 
     @pytest.mark.asyncio
-    async def test_generate_audio_data_async_handles_api_exception(
+    async def test_synthesize_async_handles_api_exception(
         self, basic_gemini_provider: GeminiTTSProvider
     ) -> None:
         """Async API exceptions should become failure Results."""
@@ -222,7 +238,7 @@ class TestGeminiTTSProviderAsyncGeneration:
         mock_client.aio.models.generate_content = fake_generate
         provider.client = mock_client
 
-        result = await provider.generate_audio_data_async("Test text")
+        result = await provider.synthesize_async("Test text")
 
         assert result.is_failure
         assert result.error is not None
@@ -235,7 +251,7 @@ class TestGeminiTTSProviderResponseParsing:
     def test_no_candidates_is_failure(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Empty candidate list should be a failure."""
         empty_response: Any = SimpleNamespace(candidates=[])
-        result = basic_gemini_provider._extract_audio_from_response(empty_response)
+        result = basic_gemini_provider._segments_from_response("Hello", empty_response)
 
         assert result.is_failure
         assert result.error is not None
@@ -244,7 +260,7 @@ class TestGeminiTTSProviderResponseParsing:
     def test_empty_content_is_failure(self, basic_gemini_provider: GeminiTTSProvider) -> None:
         """Candidate without content parts should be a failure."""
         response: Any = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[]))])
-        result = basic_gemini_provider._extract_audio_from_response(response)
+        result = basic_gemini_provider._segments_from_response("Hello", response)
 
         assert result.is_failure
         assert result.error is not None
@@ -254,24 +270,29 @@ class TestGeminiTTSProviderResponseParsing:
         """Parts without audio data should be a failure."""
         part = SimpleNamespace(inline_data=SimpleNamespace(mime_type="text/plain", data=b"not audio"))
         response: Any = SimpleNamespace(candidates=[SimpleNamespace(content=SimpleNamespace(parts=[part]))])
-        result = basic_gemini_provider._extract_audio_from_response(response)
+        result = basic_gemini_provider._segments_from_response("Hello", response)
 
         assert result.is_failure
         assert result.error is not None
         assert "No audio data" in str(result.error.details)
 
     def test_pcm_sample_rate_parsed_from_mime_type(self, basic_gemini_provider: GeminiTTSProvider) -> None:
-        """Sample rate in the PCM mime type should be honored in the WAV header."""
-        import io
-        import wave
-
+        """Sample rate in the PCM mime type should reach the segment."""
         response: Any = make_audio_response(b"\x00\x01" * 400, mime_type="audio/pcm;rate=16000")
-        result = basic_gemini_provider._extract_audio_from_response(response)
+        result = basic_gemini_provider._segments_from_response("Hello", response)
 
         assert result.is_success
         assert result.value is not None
-        with wave.open(io.BytesIO(result.value), "rb") as wav_file:
-            assert wav_file.getframerate() == 16000
+        assert result.value[0].sample_rate == 16000
+
+    def test_missing_sample_rate_falls_back_to_default(self, basic_gemini_provider: GeminiTTSProvider) -> None:
+        """A PCM mime type with no rate should not crash."""
+        response: Any = make_audio_response(b"\x00\x01" * 400, mime_type="audio/pcm")
+        result = basic_gemini_provider._segments_from_response("Hello", response)
+
+        assert result.is_success
+        assert result.value is not None
+        assert result.value[0].sample_rate == 24000
 
 
 class TestGeminiTTSProviderStylePrompt:
@@ -314,12 +335,12 @@ class TestGeminiTTSProviderStylePrompt:
         mock_client = Mock()
 
         async def fake_generate(**kwargs: object) -> SimpleNamespace:
-            return make_audio_response(b"audio")
+            return make_audio_response(b"\x00\x01" * 100, mime_type="audio/pcm;rate=24000")
 
         mock_client.aio.models.generate_content = Mock(side_effect=fake_generate)
         provider.client = mock_client
 
-        result = await provider.generate_audio_data_async("Body text.")
+        result = await provider.synthesize_async("Body text.")
 
         assert result.is_success
         contents = mock_client.aio.models.generate_content.call_args.kwargs["contents"]

--- a/tests/infrastructure/tts/test_piper_tts_provider.py
+++ b/tests/infrastructure/tts/test_piper_tts_provider.py
@@ -272,9 +272,7 @@ class TestPiperTTSProviderTextValidation:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_synthesize_rejects_ssml_only_content(
-        self, mock_run: Mock, basic_piper_config: PiperConfig
-    ) -> None:
+    def test_synthesize_rejects_ssml_only_content(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should reject content that becomes empty after SSML removal."""
         mock_run.return_value = Mock(returncode=0)
         provider = PiperTTSProvider(basic_piper_config)
@@ -429,9 +427,7 @@ class TestPiperTTSProviderAsyncGeneration:
     @pytest.mark.asyncio
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    async def test_synthesize_async_calls_sync_method(
-        self, mock_run: Mock, basic_piper_config: PiperConfig
-    ) -> None:
+    async def test_synthesize_async_calls_sync_method(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should call sync method in thread pool."""
         # Mock successful piper availability
         mock_run.return_value = Mock(returncode=0)
@@ -590,9 +586,7 @@ class TestPiperTTSProviderRealWorldScenarios:
 
         with patch.object(provider, "_synthesize_with_command_line") as mock_generate:
             mock_generate.return_value = [
-                SynthesizedSegment(
-                    text=long_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1
-                )
+                SynthesizedSegment(text=long_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1)
             ]
 
             result = provider.synthesize(long_text)
@@ -611,9 +605,7 @@ class TestPiperTTSProviderRealWorldScenarios:
 
         with patch.object(provider, "_synthesize_with_command_line") as mock_generate:
             mock_generate.return_value = [
-                SynthesizedSegment(
-                    text=unicode_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1
-                )
+                SynthesizedSegment(text=unicode_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1)
             ]
 
             result = provider.synthesize(unicode_text)

--- a/tests/infrastructure/tts/test_piper_tts_provider.py
+++ b/tests/infrastructure/tts/test_piper_tts_provider.py
@@ -13,7 +13,33 @@ import pytest
 
 from domain.config.tts_config import PiperConfig
 from domain.errors import ErrorCode, Result
+from domain.models import SynthesizedSegment
 from infrastructure.tts.piper_tts_provider import PiperTTSProvider
+from infrastructure.tts.text_segmenter import TextSegmenter
+
+
+def _piper_chunk(frames: int = 100, sample_rate: int = 100) -> Mock:
+    """A stand-in for piper's AudioChunk: 16-bit mono at a cheap sample rate."""
+    chunk = Mock()
+    chunk.sample_rate = sample_rate
+    chunk.sample_width = 2
+    chunk.sample_channels = 1
+    chunk.audio_int16_bytes = b"\x01\x00" * frames
+    return chunk
+
+
+def _wav_bytes(frames: int = 100, sample_rate: int = 100) -> bytes:
+    """A minimal but valid mono 16-bit WAV, for stubbing the CLI's output file."""
+    import io
+    import wave
+
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(sample_rate)
+        wav.writeframes(b"\x01\x00" * frames)
+    return buffer.getvalue()
 
 
 @pytest.fixture
@@ -80,7 +106,7 @@ class TestPiperTTSProviderInitialization:
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
     def test_init_with_missing_model_files_defers_error(self, mock_run: Mock, temp_models_dir: str) -> None:
-        """Should defer error for missing model files to generate_audio_data call."""
+        """Should defer error for missing model files to synthesize call."""
         # Make Piper command line available so it proceeds to model check
         mock_run.return_value = Mock(returncode=0)
 
@@ -99,7 +125,7 @@ class TestPiperTTSProviderInitialization:
         assert "not found" in provider._initialization_error.lower()
 
         # Error should be returned on first generate call
-        result = provider.generate_audio_data("Test text")
+        result = provider.synthesize("Test text")
         assert result.is_failure
         assert result.error is not None
         # Error details should contain the actual error message
@@ -200,12 +226,12 @@ class TestPiperTTSProviderTextValidation:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_generate_audio_data_rejects_empty_text(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
+    def test_synthesize_rejects_empty_text(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should reject empty text input."""
         mock_run.return_value = Mock(returncode=0)
         provider = PiperTTSProvider(basic_piper_config)
 
-        result = provider.generate_audio_data("")
+        result = provider.synthesize("")
 
         assert result.is_failure
         assert result.error is not None
@@ -213,12 +239,12 @@ class TestPiperTTSProviderTextValidation:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_generate_audio_data_rejects_whitespace_only(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
+    def test_synthesize_rejects_whitespace_only(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should reject whitespace-only text."""
         mock_run.return_value = Mock(returncode=0)
         provider = PiperTTSProvider(basic_piper_config)
 
-        result = provider.generate_audio_data("   \n\t  ")
+        result = provider.synthesize("   \n\t  ")
 
         assert result.is_failure
         assert result.error is not None
@@ -226,7 +252,7 @@ class TestPiperTTSProviderTextValidation:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_generate_audio_data_rejects_error_messages(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
+    def test_synthesize_rejects_error_messages(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should reject error message text."""
         mock_run.return_value = Mock(returncode=0)
         provider = PiperTTSProvider(basic_piper_config)
@@ -238,7 +264,7 @@ class TestPiperTTSProviderTextValidation:
         ]
 
         for error_text in error_texts:
-            result = provider.generate_audio_data(error_text)
+            result = provider.synthesize(error_text)
 
             assert result.is_failure
             assert result.error is not None
@@ -246,7 +272,7 @@ class TestPiperTTSProviderTextValidation:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_generate_audio_data_rejects_ssml_only_content(
+    def test_synthesize_rejects_ssml_only_content(
         self, mock_run: Mock, basic_piper_config: PiperConfig
     ) -> None:
         """Should reject content that becomes empty after SSML removal."""
@@ -254,7 +280,7 @@ class TestPiperTTSProviderTextValidation:
         provider = PiperTTSProvider(basic_piper_config)
 
         ssml_only = "<break time='2s'/><silence duration='1s'/>"
-        result = provider.generate_audio_data(ssml_only)
+        result = provider.synthesize(ssml_only)
 
         assert result.is_failure
         assert result.error is not None
@@ -266,13 +292,13 @@ class TestPiperTTSProviderAvailabilityChecking:
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    def test_generate_audio_data_fails_when_unavailable(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
+    def test_synthesize_fails_when_unavailable(self, mock_run: Mock, basic_piper_config: PiperConfig) -> None:
         """Should fail gracefully when Piper is not available."""
         # Mock command line check to fail
         mock_run.side_effect = FileNotFoundError("piper command not found")
 
         provider = PiperTTSProvider(basic_piper_config)
-        result = provider.generate_audio_data("Test text")
+        result = provider.synthesize("Test text")
 
         assert result.is_failure
         assert result.error is not None
@@ -316,7 +342,7 @@ class TestPiperTTSProviderCommandLineGeneration:
         mock_stat.return_value = stat_result
 
         # Mock file reading
-        fake_audio_data = b"RIFF\x24\x08\x00\x00WAVEfmt "  # WAV header
+        fake_audio_data = _wav_bytes(frames=100)  # real WAV, since the provider unwraps it
         mock_file_handle = Mock()
         mock_file_handle.read.return_value = fake_audio_data
         mock_open.return_value.__enter__.return_value = mock_file_handle
@@ -327,10 +353,14 @@ class TestPiperTTSProviderCommandLineGeneration:
             provider = PiperTTSProvider(custom_piper_config)
 
         # Test generation
-        result = provider.generate_audio_data("Hello, this is a test.")
+        result = provider.synthesize("Hello, this is a test.")
 
         assert result.is_success
-        assert result.value == fake_audio_data
+        assert result.value is not None
+        # The CLI emits a finished WAV with no sentence boundaries, so it unwraps to
+        # exactly one segment carrying the whole text
+        assert len(result.value) == 1
+        assert result.value[0].text == "Hello, this is a test."
 
         # Verify command construction
         mock_run.assert_called()
@@ -345,10 +375,12 @@ class TestPiperTTSProviderCommandLineGeneration:
         assert "0.8" in cmd  # custom length scale
         assert "--speaker" in cmd
         assert "1" in cmd  # custom speaker ID
-        # All prosody settings must reach the CLI, not just length_scale (issue #59)
+        # Voice-shaping settings must reach the CLI, not just length_scale (issue #59).
+        # Inter-sentence silence is deliberately absent: gaps are AudioAssembler's job
+        # now, so the engine must not add its own (issue #64).
         assert "--noise_scale" in cmd
         assert "--noise_w" in cmd
-        assert "--sentence_silence" in cmd
+        assert "--sentence_silence" not in cmd
 
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
@@ -363,7 +395,7 @@ class TestPiperTTSProviderCommandLineGeneration:
 
         mock_run.side_effect = TimeoutExpired("piper", 30)
 
-        result = provider.generate_audio_data("Test text")
+        result = provider.synthesize("Test text")
 
         assert result.is_failure
         assert result.error is not None
@@ -383,7 +415,7 @@ class TestPiperTTSProviderCommandLineGeneration:
         # Mock command failure
         mock_run.return_value = Mock(returncode=1, stderr="Model not found", stdout="", args=["piper"])
 
-        result = provider.generate_audio_data("Test text")
+        result = provider.synthesize("Test text")
 
         assert result.is_failure
         assert result.error is not None
@@ -397,7 +429,7 @@ class TestPiperTTSProviderAsyncGeneration:
     @pytest.mark.asyncio
     @patch("infrastructure.tts.piper_tts_provider.PIPER_VOICE_AVAILABLE", False)
     @patch("subprocess.run")
-    async def test_generate_audio_data_async_calls_sync_method(
+    async def test_synthesize_async_calls_sync_method(
         self, mock_run: Mock, basic_piper_config: PiperConfig
     ) -> None:
         """Should call sync method in thread pool."""
@@ -406,13 +438,16 @@ class TestPiperTTSProviderAsyncGeneration:
         provider = PiperTTSProvider(basic_piper_config)
 
         # Mock sync method to avoid actual TTS generation
-        with patch.object(provider, "generate_audio_data") as mock_sync:
-            mock_sync.return_value = Result.success(b"fake_audio")
+        segment = SynthesizedSegment(
+            text="Test text", pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1
+        )
+        with patch.object(provider, "synthesize") as mock_sync:
+            mock_sync.return_value = Result.success([segment])
 
-            result = await provider.generate_audio_data_async("Test text")
+            result = await provider.synthesize_async("Test text")
 
             assert result.is_success
-            assert result.value == b"fake_audio"
+            assert result.value == [segment]
             mock_sync.assert_called_once_with("Test text")
 
 
@@ -553,10 +588,14 @@ class TestPiperTTSProviderRealWorldScenarios:
         # Create long text (5000 characters)
         long_text = "This is a very long text. " * 200
 
-        with patch.object(provider, "_generate_with_command_line") as mock_generate:
-            mock_generate.return_value = b"audio_data"
+        with patch.object(provider, "_synthesize_with_command_line") as mock_generate:
+            mock_generate.return_value = [
+                SynthesizedSegment(
+                    text=long_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1
+                )
+            ]
 
-            result = provider.generate_audio_data(long_text)
+            result = provider.synthesize(long_text)
 
             # Should process without timeout errors
             mock_generate.assert_called_once_with(long_text)
@@ -570,10 +609,14 @@ class TestPiperTTSProviderRealWorldScenarios:
 
         unicode_text = "Héllo wörld! 你好世界 🌍"
 
-        with patch.object(provider, "_generate_with_command_line") as mock_generate:
-            mock_generate.return_value = b"audio_data"
+        with patch.object(provider, "_synthesize_with_command_line") as mock_generate:
+            mock_generate.return_value = [
+                SynthesizedSegment(
+                    text=unicode_text, pcm=b"\x00\x00" * 10, sample_rate=100, sample_width=2, channels=1
+                )
+            ]
 
-            result = provider.generate_audio_data(unicode_text)
+            result = provider.synthesize(unicode_text)
 
             # Should process Unicode text
             mock_generate.assert_called_once_with(unicode_text)
@@ -650,85 +693,79 @@ class TestPiperSynthesisConfig:
         assert syn_config.noise_w_scale == config.noise_w
 
 
-class TestPiperPythonLibraryAudioAssembly:
-    """Test WAV assembly on the Piper Python-library path.
+class TestPiperSegmentProduction:
+    """Test that the Python-library path returns one segment per sentence.
 
-    Covers the silence placement that survives concatenation, and the zero-chunk
-    error path that used to be masked by the wave writer.
+    Gap policy and container writing live in AudioAssembler now (issue #64); what
+    the provider owes its caller is segments whose text matches their audio.
     """
 
     @staticmethod
-    def _provider(config: PiperConfig, chunks: list[Mock]) -> PiperTTSProvider:
-        """Provider wired to a fake voice yielding the given chunks."""
+    def _provider(config: PiperConfig, chunks_per_call: int = 1, frames: int = 100) -> PiperTTSProvider:
+        """Provider wired to a fake voice yielding `chunks_per_call` chunks per call."""
         with patch.object(PiperTTSProvider, "_check_piper_availability"):
             provider = PiperTTSProvider.__new__(PiperTTSProvider)
         provider.config = config
+        provider.segmenter = TextSegmenter()
+
+        def fake_synthesize(text: str, syn_config: object) -> object:
+            return iter([_piper_chunk(frames) for _ in range(chunks_per_call)])
+
         voice = Mock()
-        voice.synthesize.return_value = iter(chunks)
+        voice.synthesize.side_effect = fake_synthesize
         provider.voice_instance = voice  # type: ignore[assignment]
         return provider
 
-    @staticmethod
-    def _chunk(frames: int = 100) -> Mock:
-        """One sentence of 16-bit mono audio at 100 Hz, for cheap frame math."""
-        chunk = Mock()
-        chunk.sample_rate = 100
-        chunk.sample_width = 2
-        chunk.sample_channels = 1
-        chunk.audio_int16_bytes = b"\x01\x00" * frames
-        return chunk
+    def test_one_segment_per_sentence_with_matching_text(self, temp_models_dir: str) -> None:
+        """Each segment must carry the exact sentence that produced its audio."""
+        provider = self._provider(PiperConfig(download_dir=temp_models_dir))
+
+        segments = provider._synthesize_with_python_lib("First sentence. Second sentence. Third sentence.")
+
+        assert [s.text for s in segments] == ["First sentence.", "Second sentence.", "Third sentence."]
+
+    def test_segment_duration_is_measured_from_samples(self, temp_models_dir: str) -> None:
+        """Duration comes from the sample count, not an estimate."""
+        provider = self._provider(PiperConfig(download_dir=temp_models_dir), frames=50)
+
+        segments = provider._synthesize_with_python_lib("One sentence.")
+
+        # 50 frames at 100 Hz
+        assert segments[0].duration == pytest.approx(0.5)
+
+    def test_sub_chunks_are_joined_into_one_segment(self, temp_models_dir: str) -> None:
+        """If Piper splits a sentence further, the pieces rejoin under the text we asked for."""
+        provider = self._provider(PiperConfig(download_dir=temp_models_dir), chunks_per_call=3, frames=50)
+
+        segments = provider._synthesize_with_python_lib("One sentence.")
+
+        assert len(segments) == 1
+        assert segments[0].text == "One sentence."
+        assert segments[0].duration == pytest.approx(1.5)  # 3 x 50 frames at 100 Hz
+
+    def test_provider_writes_no_silence_of_its_own(self, temp_models_dir: str) -> None:
+        """sentence_silence must not leak into the engine's audio (issue #64)."""
+        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=5.0)
+        provider = self._provider(config, frames=100)
+
+        segments = provider._synthesize_with_python_lib("One sentence.")
+
+        # Exactly the speech frames - a huge gap setting changes nothing here
+        assert len(segments[0].pcm) == 100 * 2
 
     def test_zero_chunks_reports_the_real_error(self, temp_models_dir: str) -> None:
-        """The raise must not happen inside the wave writer's context manager.
+        """The failure must name the cause, not a wave-header side effect."""
+        with patch.object(PiperTTSProvider, "_check_piper_availability"):
+            provider = PiperTTSProvider.__new__(PiperTTSProvider)
+        provider.config = PiperConfig(download_dir=temp_models_dir)
+        provider.segmenter = TextSegmenter()
+        voice = Mock()
+        voice.synthesize.return_value = iter([])
+        provider.voice_instance = voice  # type: ignore[assignment]
 
-        Raising in there means Wave_write.close() fails on unset params and replaces
-        the real message with a confusing "# channels not specified".
-        """
-        provider = self._provider(PiperConfig(download_dir=temp_models_dir), [])
-
-        with patch.object(provider, "_generate_with_command_line", side_effect=Exception("cli disabled")):
+        with patch.object(provider, "_synthesize_with_command_line", side_effect=Exception("cli disabled")):
             try:
-                provider._generate_with_python_lib("text")
+                provider._synthesize_with_python_lib("text")
             except Exception as exc:
-                # The CLI fallback error is what surfaces, but the *cause* must be ours
                 assert "channels not specified" not in str(exc.__context__)
                 assert "no audio chunks" in str(exc.__context__)
-
-    def test_trailing_silence_survives_chunk_concatenation(self, temp_models_dir: str) -> None:
-        """A gap after the last sentence is what keeps concatenated seams apart.
-
-        Callers synthesize ~3000-char chunks separately and concatenate them, so
-        gapping only *between* sentences leaves two sentences running together at
-        every chunk boundary.
-        """
-        import io
-        import wave
-
-        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.5)
-        provider = self._provider(config, [self._chunk(frames=100)])
-
-        with wave.open(io.BytesIO(provider._generate_with_python_lib("One sentence.")), "rb") as wav:
-            # 100 frames of speech + 0.5s at 100 Hz = 50 frames of trailing silence
-            assert wav.getnframes() == 150
-
-    def test_silence_written_between_every_sentence(self, temp_models_dir: str) -> None:
-        """Three sentences at 0.5s should gap after each one."""
-        import io
-        import wave
-
-        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.5)
-        provider = self._provider(config, [self._chunk(frames=100) for _ in range(3)])
-
-        with wave.open(io.BytesIO(provider._generate_with_python_lib("Three. Short. Sentences.")), "rb") as wav:
-            assert wav.getnframes() == 3 * (100 + 50)
-
-    def test_zero_sentence_silence_writes_no_padding(self, temp_models_dir: str) -> None:
-        """sentence_silence=0 must produce exactly the speech frames."""
-        import io
-        import wave
-
-        config = PiperConfig(download_dir=temp_models_dir, sentence_silence=0.0)
-        provider = self._provider(config, [self._chunk(frames=100) for _ in range(2)])
-
-        with wave.open(io.BytesIO(provider._generate_with_python_lib("Two. Sentences.")), "rb") as wav:
-            assert wav.getnframes() == 200

--- a/tests/integration/test_end_to_end_flask.py
+++ b/tests/integration/test_end_to_end_flask.py
@@ -26,6 +26,7 @@ from domain.config.tts_config import PiperConfig, TTSConfig, TTSEngine
 from domain.errors import Result
 from domain.models import PageRange, PDFInfo, TimedAudioResult
 from routes import register_routes
+from tests.test_helpers import fake_segments
 
 # === Flask App Test Fixtures ===
 
@@ -233,23 +234,12 @@ class TestEndToEndPDFConversion:
 
         mock_tts_instance = MagicMock()
 
-        # Mock timing-aware TTS generation
-        def generate_timed_audio_side_effect(text: str) -> Result[bytes]:
-            # Simulate timing data generation
-            text.split(". ")
+        # Mock timing-aware TTS generation: one segment per sentence, so the
+        # timing engine gets real per-sentence durations to lay out
+        def synthesize_side_effect(text: str) -> Result[object]:
+            return Result.success(fake_segments(text))
 
-            # Return audio data with embedded timing
-            audio_size = len(text) * 10
-            fake_wav_header = (
-                b"RIFF\x24\x08\x00\x00WAVEfmt \x10\x00\x00\x00"
-                b"\x01\x00\x01\x00\x44\xac\x00\x00\x88X\x01\x00"
-                b"\x02\x00\x10\x00data\x00\x08\x00\x00"
-            )
-            audio_data = fake_wav_header + b"timed_audio_" * (audio_size // 15)
-
-            return Result.success(audio_data)
-
-        mock_tts_instance.generate_audio_data.side_effect = generate_timed_audio_side_effect
+        mock_tts_instance.synthesize.side_effect = synthesize_side_effect
         mock_tts_instance.get_output_format.return_value = "wav"
         mock_tts_instance.supports_timing.return_value = True
         mock_tts_instance.supports_ssml.return_value = True
@@ -348,7 +338,7 @@ class TestEndToEndPDFConversion:
             mock_ocr.return_value = mock_ocr_instance
 
             mock_tts_instance = MagicMock()
-            mock_tts_instance.generate_audio_data.return_value = Result.success(b"fake_audio_page1")
+            mock_tts_instance.synthesize.side_effect = lambda text: Result.success(fake_segments(text))
             mock_tts_instance.get_output_format.return_value = "wav"
             mock_tts.return_value = mock_tts_instance
 

--- a/tests/integration/test_real_service_integration.py
+++ b/tests/integration/test_real_service_integration.py
@@ -315,8 +315,8 @@ class TestRealProviderInteraction:
                     if tts_engine:
                         # Test interface compliance (ITTSEngine)
                         assert isinstance(tts_engine, ITTSEngine)
-                        assert hasattr(tts_engine, "generate_audio_data")
-                        assert hasattr(tts_engine, "generate_audio_data_async")
+                        assert hasattr(tts_engine, "synthesize")
+                        assert hasattr(tts_engine, "synthesize_async")
                         assert hasattr(tts_engine, "supports_ssml")
 
                         # Test interface methods work
@@ -361,17 +361,29 @@ class TestRealExternalServicesIntegration:
 
     def test_real_piper_generates_audio(self, real_piper_tts) -> None:
         """Should generate actual audio with real Piper TTS."""
-        test_text = "Hello, this is a test of Piper text to speech."
-        result = real_piper_tts.generate_audio_data(test_text)
+        test_text = "Hello, this is a test of Piper text to speech. Here is a second sentence."
+        result = real_piper_tts.synthesize(test_text)
 
         # Should return Result pattern
         assert hasattr(result, "is_success")
         if result.is_success:
-            audio_data = result.value
-            assert audio_data is not None
-            assert len(audio_data) > 0
-            # WAV files start with RIFF header
-            assert audio_data[:4] == b"RIFF", "Expected WAV audio format"
+            segments = result.value
+            assert segments is not None
+            assert len(segments) > 0
+
+            for segment in segments:
+                assert segment.pcm, "Segment carries no audio"
+                assert segment.duration > 0, "Segment has no measurable duration"
+                assert segment.text.strip(), "Segment carries no text"
+                # Raw samples, not a container - wrapping is AudioAssembler's job
+                assert segment.pcm[:4] != b"RIFF", "Expected raw PCM, not a WAV container"
+
+            # Longer sentences must take longer, which the old even split could not express
+            if len(segments) > 1:
+                longest = max(segments, key=lambda s: len(s.text))
+                shortest = min(segments, key=lambda s: len(s.text))
+                if longest.text != shortest.text:
+                    assert longest.duration > shortest.duration
 
     def test_real_file_manager_saves_and_retrieves(self, real_file_manager) -> None:
         """Should save and retrieve files with real FileManager."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,5 +1,7 @@
 # tests/test_helpers.py
+from collections.abc import Sequence
 from pathlib import Path
+import re
 import tempfile
 
 from domain.audio.timing_engine import ITimingEngine
@@ -8,7 +10,32 @@ from domain.interfaces import (
     ILLMProvider,
     ITTSEngine,
 )
-from domain.models import PageRange, ProcessingRequest, TimedAudioResult, TimingMetadata
+from domain.models import (
+    PageRange,
+    ProcessingRequest,
+    SynthesizedSegment,
+    TimedAudioResult,
+    TimingMetadata,
+)
+
+
+def fake_segments(text: str, sample_rate: int = 100) -> list[SynthesizedSegment]:
+    """Fake segments for a piece of text, one per sentence.
+
+    Durations scale with sentence length, so tests can tell a short sentence from
+    a long one - which is exactly what the old even-split timing could not do.
+    """
+    sentences = [s.strip() for s in re.split(r"(?<=[.!?])\s+", text) if s.strip()] or [text]
+    return [
+        SynthesizedSegment(
+            text=sentence,
+            pcm=b"\x01\x00" * max(1, len(sentence)),
+            sample_rate=sample_rate,
+            sample_width=2,
+            channels=1,
+        )
+        for sentence in sentences
+    ]
 
 
 class FakeTTSEngine(ITTSEngine):
@@ -18,16 +45,16 @@ class FakeTTSEngine(ITTSEngine):
         self.should_fail = should_fail
         self.generated_texts: list[str] = []
 
-    def generate_audio_data(self, text_to_speak: str) -> Result[bytes]:
-        """Generate fake audio data for testing."""
-        self.generated_texts.append(text_to_speak)
+    def synthesize(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
+        """Produce one fake segment per sentence, sized by sentence length."""
+        self.generated_texts.append(text)
         if self.should_fail:
             return Result.failure(tts_engine_error("TTS generation failed"))
-        return Result.success(f"audio_data_for_{len(text_to_speak)}_chars".encode())
+        return Result.success(fake_segments(text))
 
-    async def generate_audio_data_async(self, text_to_speak: str) -> Result[bytes]:
+    async def synthesize_async(self, text: str) -> Result[Sequence[SynthesizedSegment]]:
         """Async version for interface compliance."""
-        return self.generate_audio_data(text_to_speak)
+        return self.synthesize(text)
 
     def supports_ssml(self) -> bool:
         """Return whether this engine supports SSML."""

--- a/tests/unit/test_audio_assembler.py
+++ b/tests/unit/test_audio_assembler.py
@@ -1,0 +1,182 @@
+"""Tests for AudioAssembler.
+
+The assembler is the single owner of gap policy and container writing (issue #64).
+The property that matters most is that the timeline it reports and the audio it
+writes use the same gaps - when those lived in different layers, they disagreed.
+"""
+
+import io
+import wave
+
+import pytest
+
+from domain.audio.audio_assembler import AudioAssembler
+from domain.models import SynthesizedSegment
+
+SAMPLE_RATE = 100  # cheap frame math: 1 frame = 10ms
+
+
+def _segment(text: str = "A sentence.", frames: int = 100, sample_rate: int = SAMPLE_RATE) -> SynthesizedSegment:
+    """16-bit mono segment of a known length."""
+    return SynthesizedSegment(
+        text=text,
+        pcm=b"\x01\x00" * frames,
+        sample_rate=sample_rate,
+        sample_width=2,
+        channels=1,
+    )
+
+
+def _frames_of(wav_bytes: bytes) -> int:
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav:
+        return wav.getnframes()
+
+
+class TestSegmentDuration:
+    """Duration is measured from the samples, never estimated."""
+
+    def test_duration_from_sample_count(self) -> None:
+        """Sample count over sample rate, nothing else."""
+        assert _segment(frames=150).duration == pytest.approx(1.5)
+
+    def test_zero_length_segment_has_zero_duration(self) -> None:
+        """No samples means no time."""
+        assert _segment(frames=0).duration == 0.0
+
+    def test_degenerate_format_does_not_divide_by_zero(self) -> None:
+        """A malformed segment must not blow up the timeline."""
+        segment = SynthesizedSegment(text="x", pcm=b"", sample_rate=0, sample_width=0, channels=0)
+
+        assert segment.duration == 0.0
+
+
+class TestWavAssembly:
+    """Assembling segments into a container."""
+
+    def test_gap_written_after_every_segment(self) -> None:
+        """Including the last, so concatenated chunks keep a gap at their seam."""
+        assembler = AudioAssembler(sentence_gap=0.5)  # 50 frames
+
+        wav = assembler.to_wav([_segment(frames=100) for _ in range(3)])
+
+        assert wav.is_success
+        assert wav.value is not None
+        assert _frames_of(wav.value) == 3 * (100 + 50)
+
+    def test_zero_gap_writes_only_speech(self) -> None:
+        """A zero gap means the audio is exactly the speech frames."""
+        assembler = AudioAssembler(sentence_gap=0.0)
+
+        wav = assembler.to_wav([_segment(frames=100), _segment(frames=100)])
+
+        assert wav.is_success
+        assert wav.value is not None
+        assert _frames_of(wav.value) == 200
+
+    def test_negative_gap_is_clamped(self) -> None:
+        """A negative gap would otherwise mean negative silence."""
+        assembler = AudioAssembler(sentence_gap=-1.0)
+
+        assert assembler.gap_duration() == 0.0
+
+    def test_empty_segments_is_a_failure(self) -> None:
+        """There is no meaningful empty WAV to return."""
+        assert AudioAssembler().to_wav([]).is_failure
+
+    def test_mismatched_formats_rejected(self) -> None:
+        """Concatenating different sample rates would silently change pitch."""
+        assembler = AudioAssembler()
+
+        result = assembler.to_wav([_segment(sample_rate=100), _segment(sample_rate=200)])
+
+        assert result.is_failure
+        assert result.error is not None
+        assert "differing formats" in (result.error.details or "")
+
+    def test_output_preserves_format(self) -> None:
+        """The container must describe the samples it holds."""
+        assembler = AudioAssembler(sentence_gap=0.1)
+
+        wav = assembler.to_wav([_segment()])
+
+        assert wav.value is not None
+        with wave.open(io.BytesIO(wav.value), "rb") as out:
+            assert out.getframerate() == SAMPLE_RATE
+            assert out.getsampwidth() == 2
+            assert out.getnchannels() == 1
+
+
+class TestTimeline:
+    """Mapping segments onto the read-along timeline."""
+
+    def test_segments_are_spaced_by_their_real_durations(self) -> None:
+        """A short and a long sentence must not get the same slot."""
+        assembler = AudioAssembler(sentence_gap=0.0)
+
+        timed, end = assembler.to_timed_segments(
+            [_segment("Short.", frames=20), _segment("A much longer sentence.", frames=200)],
+            chunk_index=0,
+            start_time=0.0,
+        )
+
+        assert timed[0].start_time == pytest.approx(0.0)
+        assert timed[0].duration == pytest.approx(0.2)
+        assert timed[1].start_time == pytest.approx(0.2)
+        assert timed[1].duration == pytest.approx(2.0)
+        assert end == pytest.approx(2.2)
+
+    def test_gap_advances_the_clock_but_is_not_part_of_a_segment(self) -> None:
+        """Highlighting should clear at the end of speech, not linger through the pause."""
+        assembler = AudioAssembler(sentence_gap=0.5)
+
+        timed, end = assembler.to_timed_segments(
+            [_segment(frames=100), _segment(frames=100)], chunk_index=0, start_time=0.0
+        )
+
+        assert timed[0].duration == pytest.approx(1.0)  # speech only
+        assert timed[1].start_time == pytest.approx(1.5)  # speech + gap
+        assert end == pytest.approx(3.0)
+
+    def test_timeline_matches_assembled_audio_duration(self) -> None:
+        """The whole point: the reported timeline and the real audio agree.
+
+        This is what the old even-split could not guarantee.
+        """
+        assembler = AudioAssembler(sentence_gap=0.3)
+        segments = [_segment("One.", frames=37), _segment("Two.", frames=211), _segment("Three.", frames=94)]
+
+        _, end = assembler.to_timed_segments(segments, chunk_index=0, start_time=0.0)
+        wav = assembler.to_wav(segments)
+
+        assert wav.value is not None
+        assert _frames_of(wav.value) / SAMPLE_RATE == pytest.approx(end)
+
+    def test_start_time_offsets_continue_across_chunks(self) -> None:
+        """Later chunks continue the timeline rather than restarting it."""
+        assembler = AudioAssembler(sentence_gap=0.0)
+
+        timed, end = assembler.to_timed_segments([_segment(frames=100)], chunk_index=2, start_time=10.0)
+
+        assert timed[0].start_time == pytest.approx(10.0)
+        assert timed[0].chunk_index == 2
+        assert end == pytest.approx(11.0)
+
+    def test_sentence_indices_are_sequential(self) -> None:
+        """Indices continue from the offset the caller supplies."""
+        assembler = AudioAssembler()
+
+        timed, _ = assembler.to_timed_segments(
+            [_segment() for _ in range(3)], chunk_index=0, start_time=0.0, first_sentence_index=5
+        )
+
+        assert [t.sentence_index for t in timed] == [5, 6, 7]
+
+    def test_segment_text_is_carried_through(self) -> None:
+        """Read-along needs the text, and it must be the text that made the audio."""
+        assembler = AudioAssembler()
+
+        timed, _ = assembler.to_timed_segments(
+            [_segment("The first one."), _segment("The second one.")], chunk_index=0, start_time=0.0
+        )
+
+        assert [t.text for t in timed] == ["The first one.", "The second one."]

--- a/tests/unit/test_system_config_yaml.py
+++ b/tests/unit/test_system_config_yaml.py
@@ -39,7 +39,6 @@ class TestSystemConfigYAMLLoading:
                 "gemini": {
                     "model_name": "test-model",
                     "voice_name": "Aoede",
-                    "use_measurement_mode": True,
                 },
                 "piper": {"model_name": "en_US-test-high", "models_dir": "test_models", "length_scale": 1.2},
             },
@@ -63,7 +62,6 @@ class TestSystemConfigYAMLLoading:
         assert config.gemini.model_name == "test-model"
         assert config.gemini.voice_name == "Aoede"
         assert config.tts.request_delay_seconds == 1.5
-        assert config.gemini.use_measurement_mode is True
         assert config.gemini.api_key == "test-api-key-123"
 
         # Text processing


### PR DESCRIPTION
Moves the TTS port up one level: engines return segments instead of an opaque audio blob, and a single `AudioAssembler` owns gap policy and container writing.

Closes #64, closes #60, closes #62.

## The problem

`ITTSEngine.generate_audio_data(str) -> Result[bytes]` was the wrong granularity. Piper yields one chunk per sentence; the adapter flattened those into a WAV, and `TimingEngine` then tried to reconstruct the discarded structure by measuring the blob and dividing the duration **evenly** across the sentences it guessed were in it.

Three consequences, all of which were reported as separate defects:

1. Structure was discarded in infrastructure, so each adapter hand-rolled WAV assembly and could get it wrong independently.
2. It was re-derived badly in the domain — a 5-word and a 40-word sentence got identical time slots.
3. Cadence policy was split across both layers: silence was inserted in the *adapter*, concatenation happened in `AudioEngine`. The gap at a chunk seam belonged to neither, which is why it went missing.

## The change

```python
@dataclass(frozen=True)
class SynthesizedSegment:
    text: str          # the sentence this audio corresponds to
    pcm: bytes         # raw samples - no container
    sample_rate: int
    sample_width: int
    channels: int

class ITTSEngine(ABC):
    def synthesize(self, text: str) -> Result[Sequence[SynthesizedSegment]]: ...
    async def synthesize_async(self, text: str) -> Result[Sequence[SynthesizedSegment]]: ...
```

- **Piper** splits into sentences itself and synthesizes each separately, so every segment carries the exact text that produced its audio. If Piper splits a sentence further, those pieces rejoin under the text we asked for.
- **Gemini** returns a single segment — degenerate, but valid, with no special-casing.
- **`AudioAssembler`** (new, in `domain/audio/`) owns the gap between segments, the WAV container, and the timeline. Because the same object decides both the gap in the audio and the gap in the timeline, the two cannot drift apart.
- **`TimingEngine`** now lays segments out using their measured durations. `TimingMode`, the dead `ESTIMATION` branch, the never-implemented `generate_audio_with_timestamps`, per-batch temp files, and duration measurement are all gone — it drops from ~500 lines to ~190.

## Verified end to end

Two chunks, three sentences of deliberately different lengths, `sentence_gap=0.3`:

```
[ 0.000 ->  0.743]  0.743s  chunk=0  'Short one.'
[ 1.043 ->  6.291]  5.248s  chunk=0  'This second sentence is considerably longer and should tak…'
[ 6.591 ->  9.377]  2.786s  chunk=1  'A third sentence lives in the next chunk entirely.'

total timeline: 9.677s
actual audio:   9.677s   (ffprobe)
drift:          0 ms
```

Durations track real sentence length rather than being three identical slots, the timeline matches the rendered audio exactly, and the chunk-1 sentence is placed correctly across the seam.

## What this closes

| Issue | How |
|---|---|
| **#62** — even split across sentences | Durations are measured per segment; the split is gone |
| **#60** — structural silence | Gap policy is now one object's decision; per-kind gaps are a field away |
| **#64** — port granularity | The port itself |

It also removes the class of bug that produced three findings in the review of #63: no adapter writes a container any more, so there is no `wave` context manager in infrastructure to raise inside, and the chunk-seam gap is the same code path as the sentence gap.

## Config

`tts.piper.sentence_silence` keeps its name and meaning but is now applied at assembly. It reads from the Piper block only because that is where it has always lived; it is engine-independent policy now, and `config.example.yaml` says so.

Removed as dead: `tts.gemini.use_measurement_mode` and `tts.gemini.measurement_mode_interval`. They only selected a `TimingMode` that no longer exists — timing is always measured.

## Tests

Full suite green. New coverage:

- `tests/unit/test_audio_assembler.py` — gap placement, format-mismatch rejection, and the timeline-matches-audio property that the even split could not satisfy.
- `TestPiperSegmentProduction` — one segment per sentence with matching text, measured durations, sub-chunk rejoining, and that the provider writes no silence of its own.
- The real-Piper integration test now asserts segments carry raw PCM (not a container) and that a longer sentence takes longer than a shorter one.

Test doubles moved to a shared `fake_segments()` helper whose durations scale with sentence length, so tests can distinguish a short sentence from a long one.

## Known limitation

Gemini has no sentence structure, so its timing stays chunk-granular. That is a real property of the engine; it is now visible in the data rather than hidden behind an estimate that looked precise.
